### PR TITLE
runtime: allow the detected save chip to be overridden (GBARECOMP_SAVE_TYPE)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,7 @@ set_property(TARGET gbarecomp_heal_gate PROPERTY POSITION_INDEPENDENT_CODE ON)
 # ─────────────────────────────────────────────────────────────────────────────
 add_library(gbarecomp_runtime STATIC
     src/runtime/runtime.cpp
+    src/runtime/save_config.cpp
     src/runtime/bios_hle.cpp
     src/runtime/generated_dispatch.cpp
     src/runtime/runtime_bus_bridge.cpp
@@ -578,6 +579,13 @@ elseif(MINGW OR WIN32)
     target_link_options(ppu_smoke_tests PRIVATE -Wl,--stack,16777216)
 endif()
 add_test(NAME ppu_smoke_tests COMMAND ppu_smoke_tests)
+
+add_executable(save_config_tests
+    tests/runtime/save_config_test.cpp
+    src/runtime/save_config.cpp)
+target_include_directories(save_config_tests PRIVATE src/runtime)
+target_link_libraries(save_config_tests PRIVATE gbarecomp_gba)
+add_test(NAME save_config_tests COMMAND save_config_tests)
 
 add_executable(presentation_layout_tests tests/presentation_layout/test_main.cpp)
 target_include_directories(presentation_layout_tests PRIVATE src/runtime)

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -47,7 +47,6 @@
 #endif
 
 #include <algorithm>
-#include <atomic>
 #include <cctype>
 #include <chrono>
 #include <condition_variable>
@@ -1241,6 +1240,40 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
         }
     }
     bus.set_rom(rom.data(), rom.size());
+
+    // ── Save-type override ───────────────────────────────────────────────
+    // detect_save_type() picks the chip from the Nintendo SDK signature
+    // string in the ROM, which is right for most carts but not all: a ROM can
+    // carry a signature for a save library it links but never drives. Boktai 1
+    // (USA) is one — it contains "EEPROM_V122" yet its save code drives the
+    // 0x0E window (SRAM/FLASH) and never touches the 0x0D EEPROM window, so
+    // signature-based detection configures the wrong chip and every save fails.
+    // There is no way to tell from the image alone which driver is live, so
+    // allow an explicit override for those carts.
+    if (const char* st = std::getenv("GBARECOMP_SAVE_TYPE")) {
+        gba::SaveType forced = header.save_type;
+        if      (std::strcmp(st, "sram")     == 0) forced = gba::SaveType::SRAM;
+        else if (std::strcmp(st, "eeprom")   == 0) forced = gba::SaveType::EEPROM;
+        else if (std::strcmp(st, "flash512") == 0) forced = gba::SaveType::Flash512;
+        else if (std::strcmp(st, "flash1m")  == 0) forced = gba::SaveType::Flash1M;
+        else {
+            std::fprintf(stderr,
+                "[gbarecomp:runtime] unknown GBARECOMP_SAVE_TYPE=\"%s\" "
+                "(sram|eeprom|flash512|flash1m)\n", st);
+            runtime_shutdown();
+            return 1;
+        }
+        if (forced != header.save_type) {
+            std::printf("save_type_override %s -> %s (detected signature "
+                        "\"%s\" @ 0x%06X)\n",
+                        gba::save_type_name(header.save_type),
+                        gba::save_type_name(forced),
+                        header.save_signature.c_str(),
+                        header.save_signature_offset);
+            header.save_type = forced;
+        }
+    }
+
     if (header.save_type == gba::SaveType::SRAM) {
         std::size_t sram_bytes = args.save_size ? args.save_size : (32 * 1024);
         bus.save().configure_sram(sram_bytes);

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -32,6 +32,7 @@
 #include "host_window.h"
 #include "runtime_arm.h"
 #include "runtime_bus_bridge.h"
+#include "save_config.h"
 #include "self_heal.h"
 #include "overlay_loader.h"
 #include "../gba/sha1.h"
@@ -107,6 +108,7 @@ struct Args {
     std::string rom_sha1;
     std::uint32_t rom_crc32 = 0;  // 0 = no CRC check (per-game TOML fills)
     std::string save_path;
+    std::optional<gba::SaveType> save_type;
     std::size_t save_size = 0;
     int steps = 16;
     int frames = -1;
@@ -543,6 +545,17 @@ bool apply_toml_file(const std::filesystem::path& path, Args* args,
             args->rom_crc32 = parse_hex_u32(val);
         } else if (section == "save" && key == "path" && !val.empty()) {
             args->save_path = resolve_config_path(base, val);
+        } else if (section == "save" && key == "type" && !val.empty()) {
+            gba::SaveType configured = gba::SaveType::Unknown;
+            if (!parse_save_type(val, &configured)) {
+                if (err) {
+                    *err = "invalid [save].type value \"" + val +
+                           "\" in " + path.string() +
+                           " (expected sram|eeprom|flash512|flash1m)";
+                }
+                return false;
+            }
+            args->save_type = configured;
         } else if (section == "save" && key == "size" && !val.empty()) {
             uint64_t n = 0;
             if (!parse_u64(val, &n) ||
@@ -1241,38 +1254,29 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
     }
     bus.set_rom(rom.data(), rom.size());
 
-    // ── Save-type override ───────────────────────────────────────────────
-    // detect_save_type() picks the chip from the Nintendo SDK signature
-    // string in the ROM, which is right for most carts but not all: a ROM can
-    // carry a signature for a save library it links but never drives. Boktai 1
-    // (USA) is one — it contains "EEPROM_V122" yet its save code drives the
-    // 0x0E window (SRAM/FLASH) and never touches the 0x0D EEPROM window, so
-    // signature-based detection configures the wrong chip and every save fails.
-    // There is no way to tell from the image alone which driver is live, so
-    // allow an explicit override for those carts.
-    if (const char* st = std::getenv("GBARECOMP_SAVE_TYPE")) {
-        gba::SaveType forced = header.save_type;
-        if      (std::strcmp(st, "sram")     == 0) forced = gba::SaveType::SRAM;
-        else if (std::strcmp(st, "eeprom")   == 0) forced = gba::SaveType::EEPROM;
-        else if (std::strcmp(st, "flash512") == 0) forced = gba::SaveType::Flash512;
-        else if (std::strcmp(st, "flash1m")  == 0) forced = gba::SaveType::Flash1M;
-        else {
-            std::fprintf(stderr,
-                "[gbarecomp:runtime] unknown GBARECOMP_SAVE_TYPE=\"%s\" "
-                "(sram|eeprom|flash512|flash1m)\n", st);
-            runtime_shutdown();
-            return 1;
-        }
-        if (forced != header.save_type) {
-            std::printf("save_type_override %s -> %s (detected signature "
-                        "\"%s\" @ 0x%06X)\n",
-                        gba::save_type_name(header.save_type),
-                        gba::save_type_name(forced),
-                        header.save_signature.c_str(),
-                        header.save_signature_offset);
-            header.save_type = forced;
-        }
+    // Resolve the save chip once, with explicit and testable precedence:
+    // ROM signature -> game config -> process environment. Keep type and
+    // capacity paired so an override cannot silently create a malformed save.
+    SaveConfiguration save_config;
+    if (!resolve_save_configuration(
+            header.save_type, args.save_type, args.save_size,
+            std::getenv("GBARECOMP_SAVE_TYPE"), &save_config, &err)) {
+        std::fprintf(stderr, "[gbarecomp:runtime] %s\n", err.c_str());
+        runtime_shutdown();
+        return 1;
     }
+    if (save_config.source != SaveTypeSource::Detected) {
+        std::printf("save_config source=%s type=%s size=%zu "
+                    "(detected=%s signature=\"%s\" @ 0x%06X)\n",
+                    save_type_source_name(save_config.source),
+                    gba::save_type_name(save_config.type),
+                    save_config.size,
+                    gba::save_type_name(header.save_type),
+                    header.save_signature.c_str(),
+                    header.save_signature_offset);
+    }
+    header.save_type = save_config.type;
+    args.save_size = save_config.size;
 
     if (header.save_type == gba::SaveType::SRAM) {
         std::size_t sram_bytes = args.save_size ? args.save_size : (32 * 1024);

--- a/src/runtime/save_config.cpp
+++ b/src/runtime/save_config.cpp
@@ -1,0 +1,135 @@
+#include "save_config.h"
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+
+namespace gbarecomp {
+namespace {
+
+std::string lower_ascii(std::string_view value) {
+    std::string result(value);
+    std::transform(result.begin(), result.end(), result.begin(),
+                   [](unsigned char c) {
+                       return static_cast<char>(std::tolower(c));
+                   });
+    return result;
+}
+
+std::string expected_size_text(gba::SaveType type) {
+    switch (type) {
+        case gba::SaveType::SRAM:     return "32768";
+        case gba::SaveType::EEPROM:   return "512 or 8192";
+        case gba::SaveType::Flash512: return "65536";
+        case gba::SaveType::Flash1M:  return "131072";
+        case gba::SaveType::Unknown:  return "0";
+    }
+    return "0";
+}
+
+}  // namespace
+
+bool parse_save_type(std::string_view value, gba::SaveType* out) {
+    if (!out) return false;
+    const std::string normalized = lower_ascii(value);
+    if (normalized == "sram") {
+        *out = gba::SaveType::SRAM;
+    } else if (normalized == "eeprom") {
+        *out = gba::SaveType::EEPROM;
+    } else if (normalized == "flash512") {
+        *out = gba::SaveType::Flash512;
+    } else if (normalized == "flash1m") {
+        *out = gba::SaveType::Flash1M;
+    } else {
+        return false;
+    }
+    return true;
+}
+
+std::size_t default_save_size(gba::SaveType type) {
+    switch (type) {
+        case gba::SaveType::SRAM:     return 32u * 1024u;
+        case gba::SaveType::EEPROM:   return 8u * 1024u;
+        case gba::SaveType::Flash512: return 64u * 1024u;
+        case gba::SaveType::Flash1M:  return 128u * 1024u;
+        case gba::SaveType::Unknown:  return 0;
+    }
+    return 0;
+}
+
+bool valid_save_size(gba::SaveType type, std::size_t size) {
+    switch (type) {
+        case gba::SaveType::SRAM:
+            return size == 32u * 1024u;
+        case gba::SaveType::EEPROM:
+            return size == 512u || size == 8u * 1024u;
+        case gba::SaveType::Flash512:
+            return size == 64u * 1024u;
+        case gba::SaveType::Flash1M:
+            return size == 128u * 1024u;
+        case gba::SaveType::Unknown:
+            return size == 0;
+    }
+    return false;
+}
+
+const char* save_type_source_name(SaveTypeSource source) noexcept {
+    switch (source) {
+        case SaveTypeSource::Detected:    return "rom-signature";
+        case SaveTypeSource::Config:      return "game-config";
+        case SaveTypeSource::Environment: return "environment";
+    }
+    return "unknown";
+}
+
+bool resolve_save_configuration(
+    gba::SaveType detected_type,
+    std::optional<gba::SaveType> configured_type,
+    std::size_t configured_size,
+    const char* environment_override,
+    SaveConfiguration* out,
+    std::string* error) {
+    if (!out) {
+        if (error) *error = "save configuration output is null";
+        return false;
+    }
+
+    SaveConfiguration resolved;
+    resolved.type = detected_type;
+    if (configured_type) {
+        resolved.type = *configured_type;
+        resolved.source = SaveTypeSource::Config;
+    }
+
+    if (environment_override) {
+        gba::SaveType forced = gba::SaveType::Unknown;
+        if (!parse_save_type(environment_override, &forced)) {
+            if (error) {
+                *error = "unknown GBARECOMP_SAVE_TYPE=\"" +
+                         std::string(environment_override) +
+                         "\" (expected sram|eeprom|flash512|flash1m)";
+            }
+            return false;
+        }
+        resolved.type = forced;
+        resolved.source = SaveTypeSource::Environment;
+    }
+
+    resolved.size = configured_size
+        ? configured_size
+        : default_save_size(resolved.type);
+    if (!valid_save_size(resolved.type, resolved.size)) {
+        if (error) {
+            *error = "save size " + std::to_string(resolved.size) +
+                     " is incompatible with " +
+                     gba::save_type_name(resolved.type) +
+                     " (expected " + expected_size_text(resolved.type) + ")";
+        }
+        return false;
+    }
+
+    *out = resolved;
+    return true;
+}
+
+}  // namespace gbarecomp

--- a/src/runtime/save_config.h
+++ b/src/runtime/save_config.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "gba_rom_header.h"
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace gbarecomp {
+
+enum class SaveTypeSource {
+    Detected,
+    Config,
+    Environment,
+};
+
+struct SaveConfiguration {
+    gba::SaveType type = gba::SaveType::Unknown;
+    std::size_t size = 0;
+    SaveTypeSource source = SaveTypeSource::Detected;
+};
+
+bool parse_save_type(std::string_view value, gba::SaveType* out);
+std::size_t default_save_size(gba::SaveType type);
+bool valid_save_size(gba::SaveType type, std::size_t size);
+const char* save_type_source_name(SaveTypeSource source) noexcept;
+
+// Resolve save settings in increasing precedence:
+// ROM signature detection -> game.toml [save].type -> environment override.
+// An explicit [save].size must be valid for the final selected chip type.
+bool resolve_save_configuration(
+    gba::SaveType detected_type,
+    std::optional<gba::SaveType> configured_type,
+    std::size_t configured_size,
+    const char* environment_override,
+    SaveConfiguration* out,
+    std::string* error);
+
+}  // namespace gbarecomp

--- a/tests/runtime/save_config_test.cpp
+++ b/tests/runtime/save_config_test.cpp
@@ -1,0 +1,79 @@
+#include "save_config.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <optional>
+#include <string>
+
+namespace {
+
+void check(bool condition, const char* message) {
+    if (condition) return;
+    std::fprintf(stderr, "save_config_tests: %s\n", message);
+    std::exit(1);
+}
+
+gbarecomp::SaveConfiguration resolve(
+    gba::SaveType detected,
+    std::optional<gba::SaveType> configured = std::nullopt,
+    std::size_t size = 0,
+    const char* environment = nullptr) {
+    gbarecomp::SaveConfiguration result;
+    std::string error;
+    check(gbarecomp::resolve_save_configuration(
+              detected, configured, size, environment, &result, &error),
+          error.c_str());
+    return result;
+}
+
+}  // namespace
+
+int main() {
+    gba::SaveType parsed = gba::SaveType::Unknown;
+    check(gbarecomp::parse_save_type("sram", &parsed) &&
+              parsed == gba::SaveType::SRAM,
+          "failed to parse sram");
+    check(gbarecomp::parse_save_type("FLASH1M", &parsed) &&
+              parsed == gba::SaveType::Flash1M,
+          "save type parsing should be case-insensitive");
+    check(!gbarecomp::parse_save_type("flash", &parsed),
+          "ambiguous flash type was accepted");
+
+    auto result = resolve(gba::SaveType::EEPROM);
+    check(result.type == gba::SaveType::EEPROM &&
+              result.size == 8192 &&
+              result.source == gbarecomp::SaveTypeSource::Detected,
+          "ROM detection did not select default EEPROM geometry");
+
+    result = resolve(gba::SaveType::EEPROM, gba::SaveType::SRAM);
+    check(result.type == gba::SaveType::SRAM &&
+              result.size == 32768 &&
+              result.source == gbarecomp::SaveTypeSource::Config,
+          "game config did not override ROM detection");
+
+    result = resolve(gba::SaveType::EEPROM, gba::SaveType::SRAM, 0,
+                     "flash1m");
+    check(result.type == gba::SaveType::Flash1M &&
+              result.size == 131072 &&
+              result.source == gbarecomp::SaveTypeSource::Environment,
+          "environment did not override game config");
+
+    result = resolve(gba::SaveType::EEPROM, gba::SaveType::EEPROM, 512);
+    check(result.size == 512, "valid 512-byte EEPROM was rejected");
+
+    gbarecomp::SaveConfiguration rejected;
+    std::string error;
+    check(!gbarecomp::resolve_save_configuration(
+              gba::SaveType::EEPROM, gba::SaveType::EEPROM, 8192,
+              "sram", &rejected, &error) &&
+              error.find("incompatible") != std::string::npos,
+          "stale EEPROM size was accepted after forcing SRAM");
+    check(!gbarecomp::resolve_save_configuration(
+              gba::SaveType::SRAM, std::nullopt, 0, "not-a-chip",
+              &rejected, &error) &&
+              error.find("unknown GBARECOMP_SAVE_TYPE") != std::string::npos,
+          "unknown environment override was accepted");
+
+    std::puts("save_config_tests: all cases passed");
+    return 0;
+}


### PR DESCRIPTION
`detect_save_type()` picks the backup chip by grepping the ROM for the Nintendo SDK signature string. That's right for most carts, but it has a real failure mode: **a ROM can carry the signature for a save library it links and never drives.**

Boktai 1 (USA) is such a cart. Its only save signature is `EEPROM_V122` at `0x584508`, so detection configures EEPROM — but measured on the bus over a 6000-frame driven run:

```
EEPROM window 0x0D......  :    0 reads, 0 writes
SRAM/FLASH    0x0E......  : 2768 accesses
```

It never touches the EEPROM window at all. Konami links Nintendo's EEPROM library and ships its own driver on the `0x0E` bus. Every save fails — the game reports *"Failed to save settings."* at its timezone prompt and *"Could not create data."* at character creation, and is unplayable past that point.

## The change

Nothing in the image says which driver is actually live, so this adds an explicit escape hatch rather than trying to guess better:

```
GBARECOMP_SAVE_TYPE=sram|eeprom|flash512|flash1m
```

It announces itself when it overrides detection, so a run that depends on it says so:

```
save_type_override EEPROM -> SRAM (detected signature "EEPROM_V" @ 0x584508)
```

An unrecognised value is a hard error, not a silent fallback.

**Deliberately not a change to the detection heuristic.** I only know it is wrong for this cart, not what the right general rule is, and reordering signature priority would risk regressing the many games detection already gets right.

## Verification

With `sram`, a 32768-byte `.sav` is written next to the ROM and **grows with progress** (2515 to 5003 non-`0xFF` bytes across a play session). The game runs from boot through character creation into gameplay, with saves persisting across restarts.

14/14 test suites pass.

## Note

A per-game `[save].type` config key would be nicer than an environment variable — the runtime already parses `[save].path` and `[save].size` — but that is a larger change and this keeps the fix reviewable. Happy to do it that way instead if you would prefer.
