### PR TITLE
PPU: implement BG bitmap modes 3, 4 and 5

### DIFF
--- a/src/gba/gba_ppu.cpp
+++ b/src/gba/gba_ppu.cpp
@@ -665,6 +665,72 @@ void render_scanline_internal(uint8_t* rgb,
         }
     };
 
+    // ── Bitmap BG modes 3/4/5 (GBATEK "LCD VRAM Bitmap BG Modes") ───────
+    // All three present a single framebuffer through BG2's affine transform,
+    // so the sampling loop mirrors render_affine_bg above:
+    //   Mode 3  240x160, 16bpp BGR555 direct colour, one frame at 0x00000.
+    //   Mode 4  240x160, 8bpp palette indices; frame 0 at 0x00000 and
+    //           frame 1 at 0x0A000, selected by DISPCNT bit 4.
+    //   Mode 5  160x128, 16bpp direct colour, same two frame bases.
+    //
+    // Transparency: mode 4 is palette-indexed, so index 0 is transparent
+    // exactly like the tiled layers. Modes 3/5 are direct colour and have no
+    // transparent index, so every in-bounds texel is opaque. Texels outside
+    // the bitmap stay transparent and show the backdrop — that is what
+    // letterboxes mode 5's 160x128 image inside the 240x160 screen.
+    //
+    // BG2CNT bit13 (display-area overflow / wraparound) is defined for the
+    // TILED affine BGs; a bitmap is not a power-of-two tile map, so an
+    // out-of-range texel here is transparent rather than wrapped.
+    auto render_bitmap_bg = [&]() {
+        if ((dispcnt & 0x0400u) == 0) return;   // DISPCNT bit10 = BG2 enable
+        constexpr uint32_t layer = 2;
+        uint16_t bgcnt = static_cast<uint16_t>(io[0x0C] | (io[0x0D] << 8));
+        int bg_priority = static_cast<int>(bgcnt & 0x3u);
+
+        const bool     direct = (bg_mode != 4);
+        const int      bmp_w  = (bg_mode == 5) ? 160 : 240;
+        const int      bmp_h  = (bg_mode == 5) ? 128 : 160;
+        const uint32_t bpp    = direct ? 2u : 1u;
+        const uint32_t frame_base =
+            (bg_mode != 3 && (dispcnt & 0x0010u) != 0) ? 0xA000u : 0x0000u;
+
+        int32_t pa   = read_s16(io, 0x20);
+        int32_t pb   = read_s16(io, 0x22);
+        int32_t pc   = read_s16(io, 0x24);
+        int32_t pd   = read_s16(io, 0x26);
+        int32_t refx = read_s28_ref(io, 0x28);
+        int32_t refy = read_s28_ref(io, 0x2C);
+        int32_t xt = refx + static_cast<int32_t>(y) * pb;
+        int32_t yt = refy + static_cast<int32_t>(y) * pd;
+        for (uint32_t x = 0; x < kScreenWidth; ++x) {
+            int32_t tex_x = xt >> 8;
+            int32_t tex_y = yt >> 8;
+            xt += pa;
+            yt += pc;
+            if (!layer_enabled(x, layer)) continue;
+            if (tex_x < 0 || tex_x >= bmp_w || tex_y < 0 || tex_y >= bmp_h)
+                continue;
+            const uint32_t off = frame_base +
+                (static_cast<uint32_t>(tex_y) * static_cast<uint32_t>(bmp_w) +
+                 static_cast<uint32_t>(tex_x)) * bpp;
+            if (off + bpp > 96u * 1024u) continue;
+            uint16_t color;
+            if (direct) {
+                color = load_u16_le(&vram[off]);
+            } else {
+                uint8_t pal_idx = vram[off];
+                if (pal_idx == 0) continue;
+                color = load_u16_le(&pal[pal_idx * 2]);
+            }
+            submit(x, color,
+                   static_cast<int>(bg_priority * 256 + 128 + layer),
+                   static_cast<uint8_t>(layer),
+                   blend_enabled(x) && ((first_targets & (1u << layer)) != 0),
+                   (second_targets & (1u << layer)) != 0);
+        }
+    };
+
     if (bg_mode == 0) {
         render_regular_bg(3, 0x0E, 0x1C);
         render_regular_bg(2, 0x0C, 0x18);
@@ -677,6 +743,9 @@ void render_scanline_internal(uint8_t* rgb,
     } else if (bg_mode == 2) {
         render_affine_bg(3, 0x0E, 0x30);
         render_affine_bg(2, 0x0C, 0x20);
+    } else if (bg_mode <= 5) {
+        // Modes 6/7 are prohibited (GBATEK); leave them backdrop-only.
+        render_bitmap_bg();
     }
 
     if (dispcnt & 0x1000u) {
@@ -1131,6 +1200,62 @@ void render_scanline_wide(uint8_t* rgb, uint32_t y, uint16_t dispcnt,
                    (second_targets & (1u << layer)) != 0);
         }
     };
+    // Bitmap BG modes 3/4/5 — see the commentary on render_bitmap_bg in
+    // render_scanline_internal above for the format/transparency rules.
+    // A bitmap has a fixed width (240, or 160 in mode 5), so there is no
+    // extra image data to reveal in the expanded margins: the affine
+    // pre-advance by -ox places the bitmap exactly where it belongs and the
+    // margins fall outside its bounds, staying backdrop.
+    auto render_bitmap_bg = [&]() {
+        if ((dispcnt & 0x0400u) == 0) return;   // DISPCNT bit10 = BG2 enable
+        constexpr uint32_t layer = 2;
+        uint16_t bgcnt = static_cast<uint16_t>(io[0x0C] | (io[0x0D] << 8));
+        int bg_priority = static_cast<int>(bgcnt & 0x3u);
+
+        const bool     direct = (bg_mode != 4);
+        const int      bmp_w  = (bg_mode == 5) ? 160 : 240;
+        const int      bmp_h  = (bg_mode == 5) ? 128 : 160;
+        const uint32_t bpp    = direct ? 2u : 1u;
+        const uint32_t frame_base =
+            (bg_mode != 3 && (dispcnt & 0x0010u) != 0) ? 0xA000u : 0x0000u;
+
+        int32_t pa   = read_s16(io, 0x20);
+        int32_t pb   = read_s16(io, 0x22);
+        int32_t pc   = read_s16(io, 0x24);
+        int32_t pd   = read_s16(io, 0x26);
+        int32_t refx = read_s28_ref(io, 0x28);
+        int32_t refy = read_s28_ref(io, 0x2C);
+        int32_t xt = refx + static_cast<int32_t>(y) * pb +
+                     static_cast<int32_t>(-static_cast<int>(ox)) * pa;
+        int32_t yt = refy + static_cast<int32_t>(y) * pd +
+                     static_cast<int32_t>(-static_cast<int>(ox)) * pc;
+        for (uint32_t x = 0; x < out_w; ++x) {
+            int32_t tex_x = xt >> 8;
+            int32_t tex_y = yt >> 8;
+            xt += pa;
+            yt += pc;
+            if (!layer_enabled(x, layer)) continue;
+            if (tex_x < 0 || tex_x >= bmp_w || tex_y < 0 || tex_y >= bmp_h)
+                continue;
+            const uint32_t off = frame_base +
+                (static_cast<uint32_t>(tex_y) * static_cast<uint32_t>(bmp_w) +
+                 static_cast<uint32_t>(tex_x)) * bpp;
+            if (off + bpp > 96u * 1024u) continue;
+            uint16_t color;
+            if (direct) {
+                color = load_u16_le(&vram[off]);
+            } else {
+                uint8_t pal_idx = vram[off];
+                if (pal_idx == 0) continue;
+                color = load_u16_le(&pal[pal_idx * 2]);
+            }
+            submit(x, color,
+                   static_cast<int>(bg_priority * 256 + 128 + layer),
+                   static_cast<uint8_t>(layer),
+                   blend_enabled(x) && ((first_targets & (1u << layer)) != 0),
+                   (second_targets & (1u << layer)) != 0);
+        }
+    };
     if (bg_mode == 0) {
         render_regular_bg(3, 0x0E, 0x1C);
         render_regular_bg(2, 0x0C, 0x18);
@@ -1143,6 +1268,9 @@ void render_scanline_wide(uint8_t* rgb, uint32_t y, uint16_t dispcnt,
     } else if (bg_mode == 2) {
         render_affine_bg(3, 0x0E, 0x30);
         render_affine_bg(2, 0x0C, 0x20);
+    } else if (bg_mode <= 5) {
+        // Modes 6/7 are prohibited (GBATEK); leave them backdrop-only.
+        render_bitmap_bg();
     }
 
     if (dispcnt & 0x1000u) {

--- a/src/gba/gba_ppu.cpp
+++ b/src/gba/gba_ppu.cpp
@@ -327,7 +327,7 @@ void mark_obj_window_scanline(bool* mask,
     if ((dispcnt & 0x8000u) == 0) return;
 
     uint32_t bg_mode = dispcnt & 0x07u;
-    uint32_t obj_tile_base = (bg_mode >= 3) ? 0x14000u : 0x10000u;
+    constexpr uint32_t obj_tile_base = 0x10000u;
     bool obj_1d_mapping = (dispcnt & 0x0040u) != 0;
 
     for (int idx = 127; idx >= 0; --idx) {
@@ -355,6 +355,10 @@ void mark_obj_window_scanline(bool* mask,
 
         bool color256 = (attr0 & 0x2000u) != 0;
         uint32_t tile_num = attr2 & 0x3FFu;
+        // Bitmap BGs consume the lower half of OBJ VRAM. Hardware preserves
+        // the normal tile-number origin and ignores tiles 0..511 rather than
+        // rebasing tile 0 to 0x14000.
+        if (bg_mode >= 3 && tile_num < 512u) continue;
         int tiles_w = sw / 8;
         int tiles_h = sh / 8;
 
@@ -749,7 +753,7 @@ void render_scanline_internal(uint8_t* rgb,
     }
 
     if (dispcnt & 0x1000u) {
-        uint32_t obj_tile_base = (bg_mode >= 3) ? 0x14000u : 0x10000u;
+        constexpr uint32_t obj_tile_base = 0x10000u;
         bool obj_1d_mapping = (dispcnt & 0x0040u) != 0;
         const uint8_t* obj_pal = pal + 0x200;
         for (int idx = 127; idx >= 0; --idx) {
@@ -773,6 +777,7 @@ void render_scanline_internal(uint8_t* rgb,
             if (sx & 0x100) sx -= 0x200;
             bool color256 = (attr0 & 0x2000u) != 0;
             uint32_t tile_num = attr2 & 0x3FFu;
+            if (bg_mode >= 3 && tile_num < 512u) continue;
             uint32_t palette_bank = (attr2 >> 12) & 0xFu;
             int tiles_w = sw / 8;
             int tiles_h = sh / 8;
@@ -1274,7 +1279,7 @@ void render_scanline_wide(uint8_t* rgb, uint32_t y, uint16_t dispcnt,
     }
 
     if (dispcnt & 0x1000u) {
-        uint32_t obj_tile_base = (bg_mode >= 3) ? 0x14000u : 0x10000u;
+        constexpr uint32_t obj_tile_base = 0x10000u;
         bool obj_1d_mapping = (dispcnt & 0x0040u) != 0;
         const uint8_t* obj_pal = pal + 0x200;
         for (int idx = 127; idx >= 0; --idx) {
@@ -1313,6 +1318,7 @@ void render_scanline_wide(uint8_t* rgb, uint32_t y, uint16_t dispcnt,
             };
             bool color256 = (attr0 & 0x2000u) != 0;
             uint32_t tile_num = attr2 & 0x3FFu;
+            if (bg_mode >= 3 && tile_num < 512u) continue;
             uint32_t palette_bank = (attr2 >> 12) & 0xFu;
             int tiles_w = sw / 8;
             int tiles_h = sh / 8;

--- a/tests/ppu_smoke/test_main.cpp
+++ b/tests/ppu_smoke/test_main.cpp
@@ -18,6 +18,13 @@ void store16(uint8_t* dst, uint16_t value) {
     dst[1] = static_cast<uint8_t>(value >> 8);
 }
 
+void store32(uint8_t* dst, uint32_t value) {
+    dst[0] = static_cast<uint8_t>(value);
+    dst[1] = static_cast<uint8_t>(value >> 8);
+    dst[2] = static_cast<uint8_t>(value >> 16);
+    dst[3] = static_cast<uint8_t>(value >> 24);
+}
+
 void expect_pixel(const uint8_t* actual,
                   uint8_t r,
                   uint8_t g,
@@ -38,6 +45,21 @@ struct Fixture {
     std::array<uint8_t, gba::GbaPpu::kFramebufferBytes> rgb{};
     gba::GbaPpu ppu;
 };
+
+void set_bg2_identity(Fixture& f) {
+    store16(&f.io[0x20], 0x0100);  // PA = 1.0
+    store16(&f.io[0x22], 0x0000);  // PB = 0.0
+    store16(&f.io[0x24], 0x0000);  // PC = 0.0
+    store16(&f.io[0x26], 0x0100);  // PD = 1.0
+    store32(&f.io[0x28], 0);       // BG2X = 0.0
+    store32(&f.io[0x2C], 0);       // BG2Y = 0.0
+}
+
+void disable_all_objects(Fixture& f) {
+    for (std::size_t i = 0; i < 128; ++i) {
+        store16(&f.oam[i * 8], 0x0200);
+    }
+}
 
 int test_positive_obj_x(int raw_x, int* out_x) {
     if (raw_x >= 0x100 && raw_x < 288 && out_x) {
@@ -638,6 +660,154 @@ void test_extended_view_extends_nearest_window_edge() {
     g_margin_provider_action = gba::kWsTilemapReplace;
 }
 
+void test_bitmap_mode3_direct_color_and_affine_origin() {
+    Fixture f;
+    set_bg2_identity(f);
+    store16(&f.pal[0], 0x7C00);  // Blue backdrop.
+
+    store16(&f.vram[(0 * 240 + 0) * 2], 0x001F);      // Red.
+    store16(&f.vram[(9 * 240 + 17) * 2], 0x03E0);     // Green.
+    store16(&f.vram[(159 * 240 + 239) * 2], 0x7C00);  // Blue.
+
+    f.ppu.render(f.rgb.data(), 0x0403, f.io.data(), f.vram.data(),
+                 f.oam.data(), f.pal.data());
+    expect_pixel(&f.rgb[(0 * 240 + 0) * 3], 255, 0, 0,
+                 "mode 3 first direct-color pixel");
+    expect_pixel(&f.rgb[(9 * 240 + 17) * 3], 0, 255, 0,
+                 "mode 3 interior direct-color pixel");
+    expect_pixel(&f.rgb[(159 * 240 + 239) * 3], 0, 0, 255,
+                 "mode 3 last direct-color pixel");
+
+    // Shift the affine origin by (17,9): screen pixel (0,0) must sample the
+    // green texel above.
+    store32(&f.io[0x28], 17u << 8);
+    store32(&f.io[0x2C], 9u << 8);
+    f.ppu.render(f.rgb.data(), 0x0403, f.io.data(), f.vram.data(),
+                 f.oam.data(), f.pal.data());
+    expect_pixel(f.rgb.data(), 0, 255, 0,
+                 "mode 3 affine origin");
+}
+
+void test_bitmap_mode4_palette_transparency_and_page_flip() {
+    Fixture f;
+    set_bg2_identity(f);
+    store16(&f.pal[0], 0x7C00);  // Blue backdrop / transparent index 0.
+    store16(&f.pal[2], 0x001F);  // Index 1 red.
+    store16(&f.pal[4], 0x03E0);  // Index 2 green.
+
+    f.vram[0] = 0;
+    f.vram[1] = 1;
+    f.vram[0xA000] = 0;
+    f.vram[0xA001] = 2;
+
+    f.ppu.render(f.rgb.data(), 0x0404, f.io.data(), f.vram.data(),
+                 f.oam.data(), f.pal.data());
+    expect_pixel(&f.rgb[0], 0, 0, 255,
+                 "mode 4 palette index 0 transparency");
+    expect_pixel(&f.rgb[3], 255, 0, 0,
+                 "mode 4 frame 0 palette lookup");
+
+    f.ppu.render(f.rgb.data(), 0x0414, f.io.data(), f.vram.data(),
+                 f.oam.data(), f.pal.data());
+    expect_pixel(&f.rgb[0], 0, 0, 255,
+                 "mode 4 frame 1 index 0 transparency");
+    expect_pixel(&f.rgb[3], 0, 255, 0,
+                 "mode 4 frame 1 page selection");
+}
+
+void test_bitmap_mode5_bounds_and_page_flip() {
+    Fixture f;
+    set_bg2_identity(f);
+    store16(&f.pal[0], 0x7FFF);  // White backdrop.
+
+    store16(&f.vram[(0 * 160 + 0) * 2], 0x001F);
+    store16(&f.vram[(127 * 160 + 159) * 2], 0x03E0);
+    store16(&f.vram[0xA000], 0x7C00);
+
+    f.ppu.render(f.rgb.data(), 0x0405, f.io.data(), f.vram.data(),
+                 f.oam.data(), f.pal.data());
+    expect_pixel(&f.rgb[(0 * 240 + 0) * 3], 255, 0, 0,
+                 "mode 5 frame 0 first pixel");
+    expect_pixel(&f.rgb[(127 * 240 + 159) * 3], 0, 255, 0,
+                 "mode 5 frame 0 last pixel");
+    expect_pixel(&f.rgb[(0 * 240 + 160) * 3], 255, 255, 255,
+                 "mode 5 right letterbox");
+    expect_pixel(&f.rgb[(128 * 240 + 0) * 3], 255, 255, 255,
+                 "mode 5 bottom letterbox");
+
+    f.ppu.render(f.rgb.data(), 0x0415, f.io.data(), f.vram.data(),
+                 f.oam.data(), f.pal.data());
+    expect_pixel(f.rgb.data(), 0, 0, 255,
+                 "mode 5 frame 1 page selection");
+}
+
+void test_bitmap_mode_obj_compositing_and_obj_window() {
+    Fixture f;
+    set_bg2_identity(f);
+    disable_all_objects(f);
+    store16(&f.io[0x0C], 1);      // BG2 priority 1.
+    store16(&f.pal[0], 0x7C00);   // Blue backdrop.
+    store16(&f.pal[2], 0x03E0);   // BG index 1 green.
+    store16(&f.pal[0x202], 0x001F);  // OBJ index 1 red.
+    std::fill_n(f.vram.begin(), 240 * 160, static_cast<uint8_t>(1));
+    std::fill_n(f.vram.begin() + 0x14000, 32, static_cast<uint8_t>(0x11));
+
+    // Normal 8x8, 4bpp OBJ at (0,0), hardware tile 512, priority 0.
+    // Bitmap modes do not rebase tile 0 to 0x14000; tiles 0..511 are ignored.
+    store16(&f.oam[0], 0x0000);
+    store16(&f.oam[2], 0x0000);
+    store16(&f.oam[4], 0x0200);
+    f.ppu.render(f.rgb.data(), 0x1404, f.io.data(), f.vram.data(),
+                 f.oam.data(), f.pal.data());
+    expect_pixel(f.rgb.data(), 255, 0, 0,
+                 "mode 4 OBJ over bitmap BG");
+    expect_pixel(&f.rgb[8 * 3], 0, 255, 0,
+                 "mode 4 bitmap BG outside OBJ");
+
+    // A populated lower OBJ tile remains unavailable in bitmap modes.
+    std::fill_n(f.vram.begin() + 0x10000, 32, static_cast<uint8_t>(0x11));
+    store16(&f.oam[4], 0x0000);
+    f.ppu.render(f.rgb.data(), 0x1404, f.io.data(), f.vram.data(),
+                 f.oam.data(), f.pal.data());
+    expect_pixel(f.rgb.data(), 0, 255, 0,
+                 "mode 4 illegal lower OBJ tile was not ignored");
+
+    // Turn that OBJ into an OBJ-window stencil. Outside enables BG2; inside
+    // disables every layer, revealing the backdrop.
+    store16(&f.oam[0], 0x0800);
+    store16(&f.oam[4], 0x0200);
+    store16(&f.io[0x4A], 0x0004);
+    f.ppu.render(f.rgb.data(), 0x8404, f.io.data(), f.vram.data(),
+                 f.oam.data(), f.pal.data());
+    expect_pixel(f.rgb.data(), 0, 0, 255,
+                 "mode 4 OBJ-window mask");
+    expect_pixel(&f.rgb[8 * 3], 0, 255, 0,
+                 "mode 4 outside OBJ-window");
+}
+
+void test_bitmap_mode_wide_center_and_margins() {
+    Fixture f;
+    set_bg2_identity(f);
+    store16(&f.pal[0], 0x7C00);  // Blue backdrop.
+    store16(&f.pal[2], 0x001F);  // Red.
+    store16(&f.pal[4], 0x03E0);  // Green.
+    f.vram[0] = 1;
+    f.vram[239] = 2;
+    f.ppu.set_view_margins(24, 24, 0, 0);
+    std::vector<uint8_t> wide(gba::GbaPpu::kMaxFramebufferBytes, 0);
+
+    f.ppu.render(wide.data(), 0x0404, f.io.data(), f.vram.data(),
+                 f.oam.data(), f.pal.data());
+    expect_pixel(wide.data(), 0, 0, 255,
+                 "mode 4 wide left margin");
+    expect_pixel(&wide[24 * 3], 255, 0, 0,
+                 "mode 4 wide authentic first pixel");
+    expect_pixel(&wide[(24 + 239) * 3], 0, 255, 0,
+                 "mode 4 wide authentic last pixel");
+    expect_pixel(&wide[(24 + 240) * 3], 0, 0, 255,
+                 "mode 4 wide right margin");
+}
+
 } // namespace
 
 int main() {
@@ -653,6 +823,11 @@ int main() {
     test_extended_view_obj_x_is_explicitly_opt_in();
     test_extended_view_obj_attr_x_is_explicitly_opt_in();
     test_extended_view_extends_nearest_window_edge();
+    test_bitmap_mode3_direct_color_and_affine_origin();
+    test_bitmap_mode4_palette_transparency_and_page_flip();
+    test_bitmap_mode5_bounds_and_page_flip();
+    test_bitmap_mode_obj_compositing_and_obj_window();
+    test_bitmap_mode_wide_center_and_margins();
     std::puts("ppu_smoke_tests: PASS");
     return 0;
 }


### PR DESCRIPTION
`render_scanline_internal()` and `render_scanline_wide()` only branched on `bg_mode` 0, 1 and 2. Modes 3/4/5 had no renderer at all, so a game that selects one composites nothing and the PPU emits only the backdrop.

That fails in a confusing way: **the game runs correctly and invisibly**, and the hang watchdog then reports an `MC-HP-002`-class busy-spin — because a software rasteriser legitimately never HALTs. Worth knowing about even aside from this patch; it cost me a while.

## The change

Adds a `render_bitmap_bg` lambda to both renderers, deliberately mirroring `render_affine_bg`: all three bitmap modes present one framebuffer through BG2's affine transform, so it reuses the same `read_s16`/`read_s28_ref` parameter fetch from `0x20..0x2C`, the same accumulate-by-PA/PC walk, and the same `submit()` priority key.

| Mode | Size | Format | Frames |
|---|---|---|---|
| 3 | 240x160 | 16bpp BGR555 direct | one, at `0x00000` |
| 4 | 240x160 | 8bpp palette indices | `0x00000` / `0x0A000` via DISPCNT bit 4 |
| 5 | 160x128 | 16bpp BGR555 direct | `0x00000` / `0x0A000` via DISPCNT bit 4 |

Per GBATEK "LCD VRAM Bitmap BG Modes". Decisions worth reviewing, all documented at the call site:

- **Transparency.** Mode 4 is palette-indexed, so index 0 is transparent like every other indexed layer. Modes 3/5 are direct colour with no transparent index, so every in-bounds texel is opaque.
- **Out-of-range texels are transparent, not wrapped.** BG2CNT bit 13 (display-area overflow) is defined for the *tiled* affine BGs; a bitmap is not a power-of-two tile map. This is also what letterboxes mode 5's 160x128 image inside the 240x160 screen.
- **Modes 6/7** are prohibited and stay backdrop-only.
- **Widescreen.** A bitmap has a fixed width, so there is no extra image data to reveal in the margins. The existing `-ox` affine pre-advance places the bitmap correctly and the margins fall outside its bounds.

## What this fixes, and what it does not

The gap is real and source-verifiable: there was no bitmap-mode renderer, so any game selecting mode 3/4/5 drew nothing but the backdrop.

**But I want to correct something I originally wrote here.** My first version of this description said the change makes Boktai 1's intro "render correctly". It does not, and I should not have claimed that.

After opening this PR, the reporter compared against a **real Boktai 1 cartridge on hardware**. The real cart goes straight from the GBA BIOS to the "Licensed by Nintendo" screen. It does **not** display the animated mode-4 swirl our build now draws at that point.

So the honest reading is: **this patch does not create that artifact, it reveals one.** The game was already executing a mode-4 sequence that real hardware does not, and the missing renderer was concealing it behind a blank screen. Making bitmap modes work turned a silent divergence into a visible one.

That is still a net improvement — a visible wrong picture is far more debuggable than a blank one, and the renderer gap needed fixing regardless — but this PR should be read as **implementing a missing PPU feature**, not as fixing Boktai's intro. The underlying divergence (why the game enters that sequence at all) is a separate bug I am still chasing, most likely around the BIOS-to-cartridge handoff.

Other scope limits, measured:

- Boktai's menus and gameplay are **mode 0** and were already correct. A/B with the bitmap path disabled vs enabled under identical driven input gives `vram_nonzero=58474` in **both** cases, with byte-identical gameplay screenshots. This changes nothing about execution or gameplay rendering.
- **No claim about MC-HP-002.** Boktai's gameplay is mode 0, so if Minish Cap is also mode 0 this is irrelevant there — worth a quick check on your side, since I cannot verify it.
- **Modes 3 and 5 are untested.** Boktai exercises only mode 4. They follow the same GBATEK rules and share the sampling loop, but no game here runs through them.

## Verification

- 14/14 test suites pass, including `ppu_smoke`.
- Modes 0/1/2 are untouched — only a new `else if` arm and a new lambda were added, so their output is byte-identical by construction.

The framebuffer was demonstrably populated and ignored before the change, which is the part that is not in question:

```
mode4_frame0[0x00000..0x09600] = 7938 non-zero   <- game's framebuffer
mode4_frame1[0x0A000..0x13600] = 0               <- correct, DISPCNT bit4 = 0
objtiles  [0x14000..0x18000]   = 7377
```
