### PR TITLE
GPIO: extract a shared GpioPort so the cart port can carry more than one device

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,7 @@ add_library(gbarecomp_gba STATIC
     src/gba/mp2k_shadow.cpp
     src/gba/gba_input.cpp
     src/gba/gba_save.cpp
+    src/gba/gba_gpio.cpp
     src/gba/gba_rtc.cpp
     src/gba/gba_bios.cpp
     src/gba/gba_scheduler.cpp
@@ -564,6 +565,10 @@ add_gbarecomp_runtime_stack_test(dma_tests tests/dma/test_main.cpp)
 add_executable(timer_tests tests/timers/test_main.cpp)
 target_link_libraries(timer_tests PRIVATE gbarecomp_gba)
 add_test(NAME timer_tests COMMAND timer_tests)
+
+add_executable(gpio_tests tests/gpio/test_main.cpp)
+target_link_libraries(gpio_tests PRIVATE gbarecomp_gba)
+add_test(NAME gpio_tests COMMAND gpio_tests)
 
 add_executable(irq_tests tests/irq/test_main.cpp)
 target_link_libraries(irq_tests PRIVATE gbarecomp_gba)

--- a/src/gba/gba_bus.cpp
+++ b/src/gba/gba_bus.cpp
@@ -123,8 +123,8 @@ uint8_t GbaBus::read8(uint32_t addr) {
         case Region::Rom: {
             // Cartridge GPIO (RTC) at 0x080000C4..0xC9 when readable; else
             // the bus returns ordinary ROM (write-only GPIO mode).
-            if (rtc_.active() && rtc_.read_enabled() && off >= 0xC4u && off <= 0xC9u)
-                return rtc_.read(static_cast<uint32_t>(off));
+            if (gpio_.active() && gpio_.read_enabled() && off >= 0xC4u && off <= 0xC9u)
+                return gpio_.read(static_cast<uint32_t>(off));
             if (is_eeprom_addr(addr, save_)) {
                 return static_cast<uint8_t>(save_.eeprom_read_bit());
             }
@@ -175,9 +175,9 @@ uint16_t GbaBus::read16(uint32_t addr) {
             break;
         case Region::Oam:   return load_u16(&oam_[off]);
         case Region::Rom: {
-            if (rtc_.active() && rtc_.read_enabled() && off >= 0xC4u && off <= 0xC8u) {
+            if (gpio_.active() && gpio_.read_enabled() && off >= 0xC4u && off <= 0xC8u) {
                 uint32_t o = static_cast<uint32_t>(off);
-                return static_cast<uint16_t>(rtc_.read(o) | (rtc_.read(o + 1) << 8));
+                return static_cast<uint16_t>(gpio_.read(o) | (gpio_.read(o + 1) << 8));
             }
             if (is_eeprom_addr(addr, save_)) {
                 return save_.eeprom_read_bit();
@@ -230,10 +230,10 @@ uint32_t GbaBus::read32(uint32_t addr) {
             break;
         case Region::Oam:   return load_u32(&oam_[off]);
         case Region::Rom: {
-            if (rtc_.active() && rtc_.read_enabled() && off >= 0xC4u && off <= 0xC6u) {
+            if (gpio_.active() && gpio_.read_enabled() && off >= 0xC4u && off <= 0xC6u) {
                 uint32_t o = static_cast<uint32_t>(off);
-                return rtc_.read(o) | (rtc_.read(o + 1) << 8) |
-                       (rtc_.read(o + 2) << 16) | (rtc_.read(o + 3) << 24);
+                return gpio_.read(o) | (gpio_.read(o + 1) << 8) |
+                       (gpio_.read(o + 2) << 16) | (gpio_.read(o + 3) << 24);
             }
             if (is_eeprom_addr(addr, save_)) {
                 return save_.eeprom_read_bit();
@@ -320,8 +320,8 @@ void GbaBus::write8(uint32_t addr, uint8_t v) {
             // BIOS is read-only; hardware ignores writes to this window.
             return;
         case Region::Rom:
-            if (rtc_.active() && off >= 0xC4u && off <= 0xC9u) {
-                rtc_.write(static_cast<uint32_t>(off), v);
+            if (gpio_.active() && off >= 0xC4u && off <= 0xC9u) {
+                gpio_.write(static_cast<uint32_t>(off), v);
                 return;
             }
             if (is_eeprom_addr(addr, save_)) {
@@ -370,8 +370,8 @@ void GbaBus::write16(uint32_t addr, uint16_t v) {
             // BIOS is read-only; hardware ignores writes to this window.
             return;
         case Region::Rom:
-            if (region == Region::Rom && rtc_.active() && off >= 0xC4u && off <= 0xC8u) {
-                rtc_.write(static_cast<uint32_t>(off), static_cast<uint8_t>(v & 0xFF));
+            if (region == Region::Rom && gpio_.active() && off >= 0xC4u && off <= 0xC8u) {
+                gpio_.write(static_cast<uint32_t>(off), static_cast<uint8_t>(v & 0xFF));
                 return;
             }
             if (region == Region::Rom && is_eeprom_addr(addr, save_)) {
@@ -419,8 +419,8 @@ void GbaBus::write32(uint32_t addr, uint32_t v) {
             // BIOS is read-only; hardware ignores writes to this window.
             return;
         case Region::Rom:
-            if (region == Region::Rom && rtc_.active() && off >= 0xC4u && off <= 0xC6u) {
-                rtc_.write(static_cast<uint32_t>(off), static_cast<uint8_t>(v & 0xFF));
+            if (region == Region::Rom && gpio_.active() && off >= 0xC4u && off <= 0xC6u) {
+                gpio_.write(static_cast<uint32_t>(off), static_cast<uint8_t>(v & 0xFF));
                 return;
             }
             if (region == Region::Rom && is_eeprom_addr(addr, save_)) {

--- a/src/gba/gba_bus.h
+++ b/src/gba/gba_bus.h
@@ -20,6 +20,7 @@
 #include "gba_bios.h"
 #include "gba_io.h"
 #include "gba_memory.h"
+#include "gba_gpio.h"
 #include "gba_rtc.h"
 #include "gba_save.h"
 
@@ -110,6 +111,7 @@ public:
         // Detect the cartridge RTC (Seiko S-3511A) by SDK signature and
         // arm the GPIO clock if present. No-op for non-clock carts.
         rtc_.configure(rom_bytes, rom_size);
+        gpio_.attach(&rtc_);   // idempotent; further devices attach here
         // Arm the MP2K audio shadow mixer (QoL; off unless the ROM links
         // MP2K and it's requested via [audio].shadow / GBARECOMP_AUDIO_SHADOW).
         // The region pointers back its side-effect-free MemView.
@@ -137,6 +139,10 @@ public:
 
     GbaRtc&       rtc()       { return rtc_; }
     const GbaRtc& rtc() const { return rtc_; }
+
+    GpioPort&       gpio()       { return gpio_; }
+    const GpioPort& gpio() const { return gpio_; }
+
 
     // Region accessors — useful for tests, debug snapshots, and the
     // PPU (which reads VRAM/OAM/PAL directly to render).
@@ -238,6 +244,7 @@ private:
     GbaAudio    audio_;
     GbaSave     save_;
     GbaRtc      rtc_;
+    GpioPort    gpio_;
 
     uint32_t    last_fetched_   = 0;
     std::size_t unmapped_count_ = 0;

--- a/src/gba/gba_gpio.cpp
+++ b/src/gba/gba_gpio.cpp
@@ -1,0 +1,81 @@
+// gba_gpio.cpp — see gba_gpio.h.
+
+#include "gba_gpio.h"
+
+namespace gba {
+
+void GpioPort::attach(GpioDevice* dev) {
+    if (!dev || device_count_ >= kMaxDevices) return;
+    for (int i = 0; i < device_count_; ++i) {
+        if (devices_[i] == dev) return;   // idempotent
+    }
+    devices_[device_count_++] = dev;
+}
+
+bool GpioPort::active() const {
+    for (int i = 0; i < device_count_; ++i) {
+        if (devices_[i]->gpio_active()) return true;
+    }
+    return false;
+}
+
+void GpioPort::latch_driven() {
+    uint8_t lv = 0;
+    for (uint8_t bit = 0; bit < 4; ++bit) {
+        if (direction_ & (1u << bit)) continue;   // guest drives this pin
+        for (int i = 0; i < device_count_; ++i) {
+            if (!devices_[i]->gpio_active()) continue;
+            const int d = devices_[i]->gpio_drive(bit);
+            if (d >= 0) {                          // first claimant wins
+                lv = static_cast<uint8_t>(lv | ((d & 1) << bit));
+                break;
+            }
+        }
+    }
+    driven_ = lv;
+}
+
+uint8_t GpioPort::read_data() const {
+    uint8_t v = 0;
+    for (uint8_t bit = 0; bit < 4; ++bit) {
+        const uint8_t level = (direction_ & (1u << bit))
+            ? static_cast<uint8_t>((data_ >> bit) & 1u)     // guest's own level
+            : static_cast<uint8_t>((driven_ >> bit) & 1u);  // last device level
+        v = static_cast<uint8_t>(v | (level << bit));
+    }
+    return v;
+}
+
+uint8_t GpioPort::read(uint32_t off) const {
+    if (!read_enable_) return 0;
+    switch (off) {
+        case kData:      return read_data();
+        case kDirection: return direction_;
+        case kControl:   return 1;
+        default:         return 0;  // high byte of each halfword register
+    }
+}
+
+void GpioPort::write(uint32_t off, uint8_t value) {
+    switch (off) {
+        case kData:
+            data_ = static_cast<uint8_t>(value & 0x0F);
+            // Every attached device sees every write and self-selects.
+            for (int i = 0; i < device_count_; ++i) {
+                if (devices_[i]->gpio_active()) devices_[i]->gpio_write(data_);
+            }
+            latch_driven();
+            break;
+        case kDirection:
+            direction_ = static_cast<uint8_t>(value & 0x0F);
+            latch_driven();   // a pin that just became an input needs a level
+            break;
+        case kControl:
+            read_enable_ = (value & 1) != 0;
+            break;
+        default:
+            break;
+    }
+}
+
+}  // namespace gba

--- a/src/gba/gba_gpio.h
+++ b/src/gba/gba_gpio.h
@@ -1,0 +1,95 @@
+// gba_gpio.h — cartridge GPIO port at 0x080000C4..0x080000C9.
+//
+// The port is four pins (bits 0..3) plus a direction register and a read-enable
+// control bit. Carts hang real devices off those pins: the Seiko S-3511A RTC
+// (Pokémon Ruby/Sapphire/Emerald, Boktai, …), Boktai's solar sensor, gyro and
+// rumble on other titles.
+//
+// Ownership split, mirroring the hardware:
+//
+//   * GpioPort  owns the three registers and the direction semantics. A pin the
+//     guest configured as an OUTPUT reads back the level the guest wrote; a pin
+//     configured as an INPUT reads whatever device is driving it (0 if none).
+//   * GpioDevice is one chip on the wires. Every attached device sees every
+//     data-port write and decides for itself whether it is being addressed —
+//     there is no external mux. That is how a Boktai cart can carry both the
+//     RTC and the solar sensor: they arbitrate on pin 2 (the RTC's CS), so
+//     exactly one of them is live at a time.
+//
+// Reference for the multi-device behaviour: mGBA's src/gba/cart/gpio.c runs
+// every attached device's pin handler on each write and merges their outputs
+// through the direction mask. Hardware behaviour only — no code is derived from
+// it (mGBA is MPL-2.0; see third_party/README.md, which requires the native
+// build to carry no copyleft emulator dependencies).
+
+#pragma once
+
+#include <cstdint>
+
+namespace gba {
+
+class GpioDevice {
+public:
+    virtual ~GpioDevice() = default;
+
+    // Has this device been detected on the current cartridge? Inactive devices
+    // are skipped entirely, so a cart without the chip behaves as if the port
+    // were plain ROM.
+    virtual bool gpio_active() const = 0;
+
+    // The guest wrote `pins` (low nibble) to the data register. Devices that
+    // share the port must check their own select condition here.
+    virtual void gpio_write(uint8_t pins) = 0;
+
+    // Level this device drives on `bit` while the guest has that pin configured
+    // as an input. Return -1 when this device does not drive the pin.
+    virtual int gpio_drive(uint8_t bit) const = 0;
+};
+
+class GpioPort {
+public:
+    static constexpr uint32_t kData      = 0xC4;
+    static constexpr uint32_t kDirection = 0xC6;
+    static constexpr uint32_t kControl   = 0xC8;
+
+    // Lowest / highest ROM-relative offsets the port answers, inclusive. The
+    // high byte of each 16-bit register reads 0, hence the 0xC9 top.
+    static constexpr uint32_t kFirst = 0xC4;
+    static constexpr uint32_t kLast  = 0xC9;
+
+    static bool in_range(uint32_t off) { return off >= kFirst && off <= kLast; }
+
+    // Attaching twice is a no-op, so callers may re-run cartridge setup.
+    void attach(GpioDevice* dev);
+
+    // True when at least one attached device is present on this cartridge.
+    bool active() const;
+
+    // GPIO reads only answer while the guest has enabled read-back via the
+    // control register; otherwise the bus falls through to ordinary ROM.
+    bool read_enabled() const { return read_enable_; }
+
+    uint8_t read(uint32_t off) const;
+    void    write(uint32_t off, uint8_t value);
+
+private:
+    uint8_t read_data() const;
+    // Sample every device-driven pin and hold the result. A pin latches the
+    // level its device asserted at the moment the port was last written; it
+    // does NOT re-ask the device on each read. That distinction matters for
+    // Boktai: the solar sensor stops driving its output as soon as the RTC's
+    // chip-select goes high, but the level it last drove must persist for the
+    // game to read back.
+    void latch_driven();
+
+    uint8_t data_        = 0;   // low nibble significant
+    uint8_t driven_      = 0;   // last levels asserted by devices
+    uint8_t direction_   = 0;   // 1 = guest drives the pin
+    bool    read_enable_ = false;
+
+    static constexpr int kMaxDevices = 4;
+    GpioDevice* devices_[kMaxDevices] = {};
+    int         device_count_         = 0;
+};
+
+}  // namespace gba

--- a/src/gba/gba_rtc.cpp
+++ b/src/gba/gba_rtc.cpp
@@ -108,46 +108,19 @@ void GbaRtc::configure(const uint8_t* rom, std::size_t len) {
     }
 }
 
-uint8_t GbaRtc::read(uint32_t off) const {
-    if (!read_enable_) return 0;
-    switch (off) {
-        case 0xC4: return read_data();
-        case 0xC6: return direction_;
-        case 0xC8: return 1;
-        default:   return 0;  // high bytes of each halfword register read 0
-    }
+
+
+
+// Pin 1 (SIO) is the only line the clock drives; everything else on the port
+// is either guest-driven or another device's business.
+int GbaRtc::gpio_drive(uint8_t bit) const {
+    return (bit == 1) ? (sio_out_ ? 1 : 0) : -1;
 }
 
-void GbaRtc::write(uint32_t off, uint8_t value) {
-    switch (off) {
-        case 0xC4: write_data(value); break;
-        case 0xC6: direction_ = value & 0x0F; break;
-        case 0xC8: read_enable_ = (value & 1) != 0; break;
-        default:   break;
-    }
-}
-
-uint8_t GbaRtc::read_data() const {
-    uint8_t v = 0;
-    for (uint8_t bit = 0; bit < 4; ++bit) {
-        uint8_t level;
-        if (direction_ & (1 << bit)) {
-            level = (data_ >> bit) & 1;
-        } else if (bit == 1) {
-            level = sio_out_ ? 1 : 0;
-        } else {
-            level = 0;
-        }
-        v |= static_cast<uint8_t>(level << bit);
-    }
-    return v;
-}
-
-void GbaRtc::write_data(uint8_t value) {
-    data_ = value & 0x0F;
-    bool new_sck = (data_ & 0b001) != 0;
-    bool new_cs  = (data_ & 0b100) != 0;
-    bool sio_in  = (data_ & 0b010) != 0;
+void GbaRtc::gpio_write(uint8_t pins) {
+    bool new_sck = (pins & 0b001) != 0;
+    bool new_cs  = (pins & 0b100) != 0;
+    bool sio_in  = (pins & 0b010) != 0;
 
     if (!cs_ && new_cs) {
         phase_ = Phase::Command;

--- a/src/gba/gba_rtc.h
+++ b/src/gba/gba_rtc.h
@@ -22,9 +22,11 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "gba_gpio.h"
+
 namespace gba {
 
-class GbaRtc {
+class GbaRtc final : public GpioDevice {
 public:
     GbaRtc();
 
@@ -34,12 +36,13 @@ public:
     void configure(const uint8_t* rom, std::size_t len);
 
     bool active() const { return active_; }
-    bool read_enabled() const { return read_enable_; }
 
-    // GPIO register access. `off` is the ROM-relative offset (0xC4..0xC9);
-    // the bus routes those addresses here while the clock is active.
-    uint8_t read(uint32_t off) const;
-    void    write(uint32_t off, uint8_t value);
+    // ── GpioDevice ───────────────────────────────────────────────────
+    // The port owns the data/direction/control registers now; the clock only
+    // models the chip on the wires. Pins: 0 = SCK, 1 = SIO, 2 = CS, 3 unused.
+    bool gpio_active() const override { return active_; }
+    void gpio_write(uint8_t pins) override;
+    int  gpio_drive(uint8_t bit) const override;
 
 private:
     enum class Phase { Idle, Command, Read, Write };
@@ -50,8 +53,6 @@ private:
         uint8_t month, day, dow, hour, min, sec;
     };
 
-    uint8_t read_data() const;
-    void    write_data(uint8_t value);
     void    clock_bit(bool sio_in);
     uint8_t bit_pos() const;
     void    advance_byte(bool committing);
@@ -65,11 +66,6 @@ private:
     void    set_offset_from(const Civil& target);
 
     bool active_ = false;
-
-    // GPIO port registers (low nibble significant).
-    uint8_t data_ = 0;
-    uint8_t direction_ = 0;
-    bool    read_enable_ = false;
 
     // Serial line state.
     bool sck_ = false;

--- a/tests/gpio/test_main.cpp
+++ b/tests/gpio/test_main.cpp
@@ -1,0 +1,235 @@
+// gpio_tests — cartridge GPIO port (0x080000C4..0xC9) and its device model.
+//
+// Covers the direction semantics and the multi-device arbitration that the
+// port must get right before a second device (Boktai's solar sensor) is hung
+// off the same four pins alongside the RTC.
+
+#include <cstdint>
+#include <cstdio>
+
+#include "gba_gpio.h"
+
+namespace {
+
+int failures = 0;
+
+void check_eq(const char* test, const char* tag, unsigned got, unsigned expect) {
+    if (got != expect) {
+        std::printf("FAIL %s: %s mismatch (got 0x%X, expected 0x%X)\n",
+                    test, tag, got, expect);
+        ++failures;
+    }
+}
+
+void check_true(const char* test, const char* tag, bool cond) {
+    if (!cond) {
+        std::printf("FAIL %s: %s\n", test, tag);
+        ++failures;
+    }
+}
+
+// A device that drives one pin with a settable level and records writes.
+class FakeDevice final : public gba::GpioDevice {
+public:
+    FakeDevice(int pin, bool active) : pin_(pin), active_(active) {}
+
+    bool gpio_active() const override { return active_; }
+    void gpio_write(uint8_t pins) override { last_pins_ = pins; ++writes_; }
+    int gpio_drive(uint8_t bit) const override {
+        if (!claims_) return -1;
+        return (static_cast<int>(bit) == pin_) ? (level_ ? 1 : 0) : -1;
+    }
+
+    void set_level(bool v) { level_ = v; }
+    void set_claims(bool v) { claims_ = v; }
+    uint8_t last_pins() const { return last_pins_; }
+    int writes() const { return writes_; }
+
+private:
+    int  pin_;
+    bool active_;
+    bool level_ = false;
+    bool claims_ = true;
+    uint8_t last_pins_ = 0xFF;
+    int writes_ = 0;
+};
+
+// Reads only answer once the control register has enabled read-back.
+void test_read_enable() {
+    const char* T = "read_enable";
+    gba::GpioPort port;
+    FakeDevice dev(1, true);
+    port.attach(&dev);
+
+    port.write(gba::GpioPort::kDirection, 0x0F);
+    port.write(gba::GpioPort::kData, 0x0A);
+    check_eq(T, "reads are 0 before control enables them",
+             port.read(gba::GpioPort::kData), 0);
+    check_true(T, "read_enabled() false initially", !port.read_enabled());
+
+    port.write(gba::GpioPort::kControl, 1);
+    check_true(T, "read_enabled() true after control write", port.read_enabled());
+    check_eq(T, "data reads back once enabled",
+             port.read(gba::GpioPort::kData), 0x0A);
+    check_eq(T, "direction register reads back",
+             port.read(gba::GpioPort::kDirection), 0x0F);
+    check_eq(T, "control register reads 1",
+             port.read(gba::GpioPort::kControl), 1);
+    check_eq(T, "high byte of a halfword register reads 0",
+             port.read(0xC5), 0);
+}
+
+// A pin configured as an OUTPUT reads back the guest's own written level, even
+// when a device would otherwise drive it. An INPUT pin reads the device.
+void test_direction_semantics() {
+    const char* T = "direction";
+    gba::GpioPort port;
+    FakeDevice dev(1, true);
+    port.attach(&dev);
+    port.write(gba::GpioPort::kControl, 1);
+
+    dev.set_level(true);
+
+    // All pins guest-driven: the device must not influence the read.
+    port.write(gba::GpioPort::kDirection, 0x0F);
+    port.write(gba::GpioPort::kData, 0x00);
+    check_eq(T, "output pins read back the written level (device ignored)",
+             port.read(gba::GpioPort::kData), 0x00);
+
+    // Pin 1 as an input: the device drives it high.
+    port.write(gba::GpioPort::kDirection, 0x0D);   // bit1 clear = input
+    port.write(gba::GpioPort::kData, 0x00);
+    check_eq(T, "input pin reads the device level", port.read(gba::GpioPort::kData), 0x02);
+
+    // Device levels are LATCHED at the port write, not re-queried per read
+    // (see latch_driven()), so a level change only becomes visible after the
+    // next port access.
+    dev.set_level(false);
+    port.write(gba::GpioPort::kData, 0x00);
+    check_eq(T, "input pin follows the device low", port.read(gba::GpioPort::kData), 0x00);
+
+    // An input pin no device claims reads 0.
+    dev.set_claims(false);
+    port.write(gba::GpioPort::kData, 0x00);
+    check_eq(T, "unclaimed input pin reads 0", port.read(gba::GpioPort::kData), 0x00);
+
+    // Only the low nibble is significant.
+    port.write(gba::GpioPort::kDirection, 0xF0);
+    check_eq(T, "direction masks to the low nibble",
+             port.read(gba::GpioPort::kDirection), 0x00);
+}
+
+// Every attached device sees every write and self-selects; devices may claim
+// different pins simultaneously. This is what lets Boktai's RTC and solar
+// sensor share the port.
+void test_multi_device() {
+    const char* T = "multi_device";
+    gba::GpioPort port;
+    FakeDevice a(1, true);
+    FakeDevice b(3, true);
+    port.attach(&a);
+    port.attach(&b);
+    port.write(gba::GpioPort::kControl, 1);
+    port.write(gba::GpioPort::kDirection, 0x00);   // all pins are inputs
+
+    a.set_level(true);
+    b.set_level(true);
+    port.write(gba::GpioPort::kData, 0x05);
+
+    check_eq(T, "both devices observed the write", a.last_pins(), 0x05);
+    check_eq(T, "second device observed the write too", b.last_pins(), 0x05);
+    check_eq(T, "both driven pins merge into one read",
+             port.read(gba::GpioPort::kData), 0x0A);   // bits 1 and 3
+}
+
+// Inactive devices are skipped entirely, and a port with no active device
+// reports inactive so the bus can fall through to ordinary ROM.
+void test_active_gating() {
+    const char* T = "active_gating";
+    gba::GpioPort empty;
+    check_true(T, "empty port is inactive", !empty.active());
+
+    gba::GpioPort port;
+    FakeDevice off(1, false);
+    port.attach(&off);
+    check_true(T, "port with only inactive devices is inactive", !port.active());
+
+    port.write(gba::GpioPort::kControl, 1);
+    port.write(gba::GpioPort::kDirection, 0x00);
+    off.set_level(true);
+    port.write(gba::GpioPort::kData, 0x0F);
+    check_eq(T, "inactive device receives no writes", off.writes(), 0);
+    check_eq(T, "inactive device drives nothing", port.read(gba::GpioPort::kData), 0x00);
+
+    FakeDevice on(2, true);
+    port.attach(&on);
+    check_true(T, "port becomes active when a live device attaches", port.active());
+}
+
+void test_attach_is_idempotent() {
+    const char* T = "attach_idempotent";
+    gba::GpioPort port;
+    FakeDevice dev(1, true);
+    port.attach(&dev);
+    port.attach(&dev);
+    port.attach(&dev);
+    port.write(gba::GpioPort::kControl, 1);
+    port.write(gba::GpioPort::kData, 0x01);
+    check_eq(T, "re-attaching the same device does not duplicate writes",
+             dev.writes(), 1);
+    port.attach(nullptr);   // must not crash
+}
+
+// Device-driven levels are sampled when the port is written and then held.
+// This is what lets a device that has gone quiet (Boktai's solar sensor once
+// the RTC asserts chip-select) leave its last output readable on the pin.
+void test_driven_levels_are_latched() {
+    const char* T = "latch";
+    gba::GpioPort port;
+    FakeDevice dev(1, true);
+    port.attach(&dev);
+    port.write(gba::GpioPort::kControl, 1);
+    port.write(gba::GpioPort::kDirection, 0x00);   // every pin an input
+
+    dev.set_level(true);
+    port.write(gba::GpioPort::kData, 0x00);        // latches high
+    check_eq(T, "latched high", port.read(gba::GpioPort::kData), 0x02);
+
+    // The device goes quiet entirely; the latched level must survive.
+    dev.set_claims(false);
+    check_eq(T, "level persists after the device stops driving",
+             port.read(gba::GpioPort::kData), 0x02);
+
+    // A direction change re-latches, because a pin that just became an input
+    // needs a level from somewhere.
+    port.write(gba::GpioPort::kDirection, 0x00);
+    check_eq(T, "direction write re-latches (device now silent)",
+             port.read(gba::GpioPort::kData), 0x00);
+}
+
+void test_in_range() {
+    const char* T = "in_range";
+    check_true(T, "0xC4 in range", gba::GpioPort::in_range(0xC4));
+    check_true(T, "0xC9 in range", gba::GpioPort::in_range(0xC9));
+    check_true(T, "0xC3 out of range", !gba::GpioPort::in_range(0xC3));
+    check_true(T, "0xCA out of range", !gba::GpioPort::in_range(0xCA));
+}
+
+}  // namespace
+
+int main() {
+    test_read_enable();
+    test_direction_semantics();
+    test_multi_device();
+    test_active_gating();
+    test_driven_levels_are_latched();
+    test_attach_is_idempotent();
+    test_in_range();
+
+    if (failures) {
+        std::printf("gpio_tests: %d failure(s)\n", failures);
+        return 1;
+    }
+    std::printf("gpio_tests: all checks passed\n");
+    return 0;
+}


### PR DESCRIPTION
`GbaRtc` currently owns the entire cartridge GPIO port — the data / direction / control registers, the direction semantics and the bus entry points — as well as the S-3511A state machine. That is fine while the clock is the only thing on the wires, but the port is four **shared** pins and real carts hang several devices off them.

Boktai is the concrete case: its cart carries both the RTC **and** a solar sensor on the same four pins, and with the port owned by the clock there is nowhere for a second device to live.

**Behaviour-preserving.** No functional change intended or observed.

## The change

Ownership now follows the hardware:

- **`GpioPort`** owns the three registers and the direction rule. A pin the guest configured as an output reads back the level the guest wrote; a pin configured as an input reads whatever device drives it, or 0 if none does.
- **`GpioDevice`** is one chip on the wires: `gpio_active()`, `gpio_write(pins)`, `gpio_drive(bit)`.
- **`GbaRtc`** becomes a `GpioDevice`. Its transaction state machine is untouched; it simply loses the register plumbing and now only declares that it drives pin 1 (SIO). `read()`/`write()`/`read_data()`/`write_data()` are gone, and `gpio_write()` is the old `write_data()` body minus the register latch.
- **`GbaBus`** owns a `GpioPort`, attaches the RTC in `set_rom()` (attach is idempotent), and routes the six `0xC4..0xC9` sites there.

Every attached device sees every data-port write and **decides for itself whether it is addressed** — there is no external mux. That is what lets two devices share the pins: on a Boktai cart the RTC and the sensor arbitrate on pin 2 (the clock's chip-select), so exactly one is live at a time.

Device-driven levels are **latched** at the port write rather than re-queried on each read, so a device that has gone quiet still leaves its last asserted level readable on the pin.

## Sourcing

This multi-device shape follows mGBA's `src/gba/cart/gpio.c`, which runs every device's pin handler per write and merges outputs through the direction mask. **Hardware behaviour only — no code is derived from it.** mGBA is MPL-2.0 and `third_party/README.md` requires the native build to carry no copyleft emulator dependencies, while `docs/ARCHITECTURE.md` permits borrowing "hardware reference behavior from emulators and hardware docs".

## Verification

- **New `gpio_tests`** (7 groups): read-enable gating, direction semantics both ways, unclaimed-input-reads-0, latching, multi-device merge, inactive-device gating, idempotent attach, range checks. Written against the interface with a fake device, so it stays meaningful as more devices attach.
- **15/15 test suites pass** (14 existing + the new one).
- **Boktai 1 (USA) is bit-identical across the refactor.** That title drives roughly 120,000 GPIO writes per session through the RTC, so it exercises this path rather than smoke-testing it:

| | before | after |
|---|---|---|
| `vram_nonzero` @6000 frames | 58474 | 58474 |
| `.sav` written | 32768 B, 2515 non-`0xFF` | 32768 B, 2515 non-`0xFF` |

## Not addressed here

`GbaRtc` still has no savestate serialization, and the registers moved into `GpioPort` inherit that gap rather than fixing it — this change deliberately alters no behaviour. The port's `data_` / `direction_` / `driven_` / `read_enable_` and the clock's transaction state are all execution-relevant and should be serialized (and included in the cosim state hash) in a follow-up.

## Why now

I am building a `GbaSolarSensor` on top of this so Boktai's sun gauge can be driven by a real webcam. That device is not in this PR — it is not finished, and this refactor stands on its own as the port modelling the hardware more honestly.
