### PR TITLE
build: stop codegen_tests colliding with its own generated directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -597,7 +597,7 @@ add_test(NAME heal_gate_tests COMMAND heal_gate_tests)
 #   1. tests/codegen/test_cases.cpp lists per-IrOp test cases.
 #   2. gen_codegen_tests.exe reads that list, invokes the same
 #      ArmCodegen used by tools/gba_recompile, and emits one C
-#      function per case into ${CMAKE_BINARY_DIR}/codegen_tests/
+#      function per case into ${CMAKE_BINARY_DIR}/codegen_tests_generated/
 #      test_funcs.cpp.
 #   3. codegen_tests.exe links test_main.cpp + test_cases.cpp +
 #      stubs.cpp + the generated test_funcs.cpp against
@@ -617,8 +617,12 @@ target_include_directories(gen_codegen_tests PRIVATE
     src/armv4t)
 target_link_libraries(gen_codegen_tests PRIVATE gbarecomp_armv4t)
 
+# NOTE: must not collide with the codegen_tests TARGET name. On Windows the
+# executable gains a .exe suffix so a same-named directory is harmless, but on
+# macOS/Linux the linker output path and this directory are the same string and
+# the link fails with "Is a directory" (errno 21).
 set(CODEGEN_TESTS_OUTDIR
-    ${CMAKE_CURRENT_BINARY_DIR}/codegen_tests)
+    ${CMAKE_CURRENT_BINARY_DIR}/codegen_tests_generated)
 set(CODEGEN_TESTS_GENFILE
     ${CODEGEN_TESTS_OUTDIR}/test_funcs.cpp)
 


### PR DESCRIPTION
`codegen_tests` is both a CMake **target** and the name of the **directory** the generated test functions are emitted into:

```cmake
# :627
set(CODEGEN_TESTS_OUTDIR ${CMAKE_CURRENT_BINARY_DIR}/codegen_tests)
# :643
add_executable(codegen_tests ...)
```

On Windows the executable gains a `.exe` suffix, so the two never collide. On macOS and Linux they resolve to the same path and the link fails:

```
ld: open() failed, errno=21 (Is a directory) for 'codegen_tests'
clang++: error: linker command failed with exit code 1
```

This renames the generated directory to `codegen_tests_generated` and adds a comment explaining why the two names must differ.

## Why it is worth taking

Everything else already works off-Windows. On macOS arm64 (M4, macOS 26, AppleClang 21, SDL2 via Homebrew `sdl2-compat`) the tree builds with **zero source changes** and every test suite passes — this one target was the sole failure, and it took the whole `cmake --build` with it.

With the rename, `codegen_tests` builds and runs for the first time on this platform:

```
codegen_tests: 131 cases
codegen_tests: all 131 cases passed
```

So the L1 per-IrOp codegen diff harness has been silently unavailable to non-Windows contributors, and it passes cleanly once it can link.

## Scope

Build-system only. No source, no behaviour, no test content changes. It affects Linux exactly as much as macOS, so this is a Unix build fix rather than a platform-support feature.

## Related, not included

Two other Windows assumptions I noticed but deliberately left alone:

- `overlay_compile.cpp:61` hardcodes `C:/msys64/mingw64/bin/g++.exe` as the self-heal compiler. It is already overridable via `GBARECOMP_HEAL_CXX`, and changing the default would not actually enable Stage-2 healing elsewhere, because `load_and_resolve` is genuinely unimplemented off-Windows ("overlay loading unimplemented on this platform"). A real fix there means implementing `dlopen` loading — a feature, not a build fix, and out of scope here.
- `RELEASE_NOTES.md` quotes the BIOS CRC32 as `0x21A2AE0A`, while the authoritative constant in `gba_bios.h:33` is `0x81977335` — which is what a genuine dump actually hashes to. Harmless, since the gate is SHA-1, but confusing when verifying a BIOS. Happy to send that as a separate one-line docs PR if you want it.
