### PR TITLE
oracle: make the mGBA oracle buildable on macOS (and Linux)

### DIFF
--- a/oracle/CMakeLists.txt
+++ b/oracle/CMakeLists.txt
@@ -34,6 +34,13 @@ if(WIN32 OR MSYS)
     # basic socket libs.
     target_link_libraries(gbarecomp_oracle PRIVATE
         ws2_32 shlwapi winmm ole32 uuid)
+elseif(APPLE)
+    # Same function, other platform: mCoreConfigPortablePath uses
+    # CFBundleGetMainBundle / CFURL* / kCFAllocatorDefault on macOS, so
+    # libmgba needs CoreFoundation. Without it the oracle fails to link
+    # with undefined _CFBundle*/_CFURL*/_kCFAllocatorDefault.
+    target_link_libraries(gbarecomp_oracle PRIVATE
+        "-framework CoreFoundation")
 endif()
 target_compile_definitions(gbarecomp_oracle PRIVATE
     M_CORE_GBA=1

--- a/oracle/setup-mgba.sh
+++ b/oracle/setup-mgba.sh
@@ -3,8 +3,8 @@
 # and build libmgba. Idempotent (skips clone/apply when already done).
 #
 # Usage: from gbarecomp/ root, run `bash oracle/setup-mgba.sh`.
-# Requires MSYS2 MinGW64 (the build is driven via cmake from PowerShell
-# afterwards). See oracle/README.md for the full flow.
+# On Windows this expects MSYS2 MinGW64 (the build is then driven via cmake
+# from PowerShell). macOS/Linux need no extra shell. See oracle/README.md.
 
 set -euo pipefail
 
@@ -12,6 +12,14 @@ REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 MGBA_DIR="$REPO_ROOT/third_party/mgba"
 MGBA_TAG="0.10.5"
 PATCHES_DIR="$REPO_ROOT/oracle/patches"
+
+# Both patches in oracle/patches/ are Windows-specific — 0001 makes MSYS look
+# like Windows to mGBA's CMake, and 0002 drops a SIGTRAP path that only exists
+# there. Applying them off-Windows misconfigures the build, so gate on the host.
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) HOST_IS_WINDOWS=1 ;;
+    *)                    HOST_IS_WINDOWS=0 ;;
+esac
 
 if [ ! -d "$MGBA_DIR/.git" ]; then
     echo "==> Cloning mGBA $MGBA_TAG into $MGBA_DIR"
@@ -25,23 +33,38 @@ fi
 # the patched line in the target file — `git apply --check` would also
 # work but is noisier.
 cd "$MGBA_DIR"
-if ! grep -q '^if(MSYS)' CMakeLists.txt; then
-    echo "==> Applying 0001-msys2-as-windows.patch"
-    git apply "$PATCHES_DIR/0001-msys2-as-windows.patch"
-fi
-if grep -q '^#ifdef USE_PTHREADS$' src/core/thread.c; then
-    echo "==> Applying 0002-windows-no-sigtrap.patch"
-    git apply "$PATCHES_DIR/0002-windows-no-sigtrap.patch"
+if [ "$HOST_IS_WINDOWS" -eq 1 ]; then
+    if ! grep -q '^if(MSYS)' CMakeLists.txt; then
+        echo "==> Applying 0001-msys2-as-windows.patch"
+        git apply "$PATCHES_DIR/0001-msys2-as-windows.patch"
+    fi
+    if grep -q '^#ifdef USE_PTHREADS$' src/core/thread.c; then
+        echo "==> Applying 0002-windows-no-sigtrap.patch"
+        git apply "$PATCHES_DIR/0002-windows-no-sigtrap.patch"
+    fi
+else
+    echo "==> Non-Windows host: skipping the two MSYS/Windows patches"
 fi
 
-echo "==> mGBA source ready. Now from PowerShell:"
-echo "    cd third_party\\mgba"
-echo "    cmake -B build -S . -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \\"
-echo "        -DLIBMGBA_ONLY=ON -DBUILD_QT=OFF -DBUILD_SDL=OFF \\"
-echo "        -DUSE_FFMPEG=OFF -DUSE_LIBZIP=OFF -DUSE_LZMA=OFF \\"
-echo "        -DUSE_EPOXY=OFF -DUSE_DEBUGGERS=OFF \\"
-echo "        -DBUILD_GL=OFF -DBUILD_GLES2=OFF -DBUILD_GLES3=OFF"
-echo "    cmake --build build -j 8"
-echo "Then back at gbarecomp/ root:"
-echo "    cmake -B build -S . -DGBARECOMP_BUILD_ORACLE=ON"
-echo "    cmake --build build --target gbarecomp_oracle"
+CMAKE_ARGS="-DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DLIBMGBA_ONLY=ON \
+-DBUILD_QT=OFF -DBUILD_SDL=OFF -DUSE_FFMPEG=OFF -DUSE_LIBZIP=OFF \
+-DUSE_LZMA=OFF -DUSE_EPOXY=OFF -DUSE_DEBUGGERS=OFF -DBUILD_GL=OFF \
+-DBUILD_GLES2=OFF -DBUILD_GLES3=OFF"
+
+if [ "$HOST_IS_WINDOWS" -eq 1 ]; then
+    echo "==> mGBA source ready. Now from PowerShell:"
+    echo "    cd third_party\\mgba"
+    echo "    cmake -B build -S . $CMAKE_ARGS"
+    echo "    cmake --build build -j 8"
+    echo "Then back at gbarecomp/ root:"
+    echo "    cmake -B build -S . -DGBARECOMP_BUILD_ORACLE=ON"
+    echo "    cmake --build build --target gbarecomp_oracle"
+else
+    echo "==> Building libmgba"
+    cmake -B build -S . $CMAKE_ARGS >/dev/null
+    cmake --build build -j "$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
+    echo "==> libmgba built at $MGBA_DIR/build/libmgba.a"
+    echo "Now from gbarecomp/ root:"
+    echo "    cmake -B build -S . -DGBARECOMP_BUILD_ORACLE=ON"
+    echo "    cmake --build build --target gbarecomp_oracle"
+fi


### PR DESCRIPTION
The oracle binary could not be built off Windows at all, which meant the differential-testing workflow the project is designed around was unavailable there. Two separate blockers, one file each.

## 1. `oracle/CMakeLists.txt` — link CoreFoundation on Apple

mGBA's `mCoreConfigPortablePath()` uses `CFBundleGetMainBundle` / `CFURL*` / `kCFAllocatorDefault` on macOS to locate the bundle directory. That's the same job the existing `WIN32` branch links `ole32` + `uuid` for (`SHGetKnownFolderPath` for `%APPDATA%`), so this is just the symmetric `elseif(APPLE)`.

Without it:

```
Undefined symbols for architecture arm64:
  "_CFBundleCopyBundleURL", referenced from:
      _mCoreConfigPortablePath in libmgba.a(config.c.o)
  "_CFBundleGetMainBundle", "_CFRelease",
  "_CFURLCreateCopyDeletingLastPathComponent",
  "_CFURLGetFileSystemRepresentation", "_kCFAllocatorDefault"
```

## 2. `oracle/setup-mgba.sh` — don't apply the Windows patches off Windows

Both patches in `oracle/patches/` are Windows-specific: `0001` makes MSYS look like Windows to mGBA's CMake, `0002` removes a SIGTRAP path that only exists there. The script applied them unconditionally, which misconfigures the build on any other host. Now gated on `uname -s`.

The script also ended by printing PowerShell-only instructions. On a non-Windows host it now runs the libmgba build itself with the same flag set and prints the two remaining commands. Re-running stays idempotent.

## Verification

On macOS arm64 (M4, macOS 26, AppleClang 21): `setup-mgba.sh` clones mGBA 0.10.5, skips the Windows patches, builds `libmgba.a`, and

```
cmake -B build -S . -DGBARECOMP_BUILD_ORACLE=ON
cmake --build build --target gbarecomp_oracle
```

produces a working 1.1 MB oracle serving the `emu_*` command set over TCP.

As evidence it actually works — comparing a recompiled run against mGBA at the same VBlank showed a Boktai ROM whose mode-4 framebuffer and palette were **byte-identical** to mGBA's (0/38400 and 0/512 differing bytes). Separately, one `emu_screenshot` identified that same ROM as an **intro-patched image rather than a clean dump**, which a full session of indirect probing had missed.

## Not addressed here

Worth knowing for anyone using the oracle off-Windows, and happy to send as follow-ups:

- **26 scripts under `oracle/` hardcode a `.exe` suffix** on `bios_smoke` / `gbarecomp_oracle` / the game exe, so they need the same platform treatment before they run.
- **`find_first_diverge.py` is BIOS-only** — it never passes `--rom`, so cartridge divergence needs a separate driver. I wrote a small cart-aware one locally (spawn both, `run_frames` vs `emu_step_to_vblank`, then diff VRAM/PAL/IO) and can contribute it if useful.
