### PR TITLE
Boktai solar sensor, cart-aware oracle diffing, and oracle .exe portability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,7 @@ add_library(gbarecomp_gba STATIC
     src/gba/gba_save.cpp
     src/gba/gba_gpio.cpp
     src/gba/gba_gyro.cpp
+    src/gba/gba_solar.cpp
     src/gba/gba_rtc.cpp
     src/gba/gba_bios.cpp
     src/gba/gba_scheduler.cpp

--- a/oracle/cycle_onset.py
+++ b/oracle/cycle_onset.py
@@ -19,13 +19,16 @@ for a tight cycle-aligned instruction window around the real first divergence.
 """
 from __future__ import annotations
 import argparse, json, os, pathlib, socket, subprocess, sys, time
+import sys as _sys, pathlib as _pl
+_sys.path.insert(0, str(_pl.Path(__file__).resolve().parent))
+from recomp_paths import exe_name
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 PROJ = ROOT.parent / "MinishCapRecomp"
 RECOMP_EXE = pathlib.Path(os.environ.get(
-    "GBARECOMP_RECOMP_EXE", PROJ / "build" / "MinishCapRecomp.exe"))
+    "GBARECOMP_RECOMP_EXE", PROJ / "build" / exe_name("MinishCapRecomp")))
 INTERP_EXE = pathlib.Path(os.environ.get(
-    "GBARECOMP_INTERP_EXE", ROOT / "build" / "bios_smoke.exe"))
+    "GBARECOMP_INTERP_EXE", ROOT / "build" / exe_name("bios_smoke")))
 BIOS = ROOT / "bios" / "gba_bios.bin"
 ROM = PROJ / "roms" / "minishcap_usa.gba"
 START_KEYINPUT = 0x3F7

--- a/oracle/diff_anim.py
+++ b/oracle/diff_anim.py
@@ -25,9 +25,12 @@ from typing import Optional
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent          # gbarecomp/
 import recomp_paths as _rp
+import sys as _sys, pathlib as _pl
+_sys.path.insert(0, str(_pl.Path(__file__).resolve().parent))
+from recomp_paths import exe_name
 PROJ = _rp.game_dir(ROOT)
 RECOMP_EXE = _rp.recomp_exe(ROOT)
-INTERP_EXE = ROOT / "build" / "bios_smoke.exe"
+INTERP_EXE = ROOT / "build" / exe_name("bios_smoke")
 BIOS = ROOT / "bios" / "gba_bios.bin"
 ROM = PROJ / "roms" / "minishcap_usa.gba"
 DEF_STATE = PROJ / "roms" / "minishcap_usa.state3"

--- a/oracle/diff_audio.py
+++ b/oracle/diff_audio.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 import argparse
 import json
 import pathlib
+import sys as _sys, pathlib as _pl
+_sys.path.insert(0, str(_pl.Path(__file__).resolve().parent))
+from recomp_paths import exe_name
 import socket
 import struct
 import subprocess
@@ -14,8 +17,8 @@ import time
 from typing import Optional
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
-BIOS_SMOKE = ROOT / "build" / "bios_smoke.exe"
-ORACLE = ROOT / "build" / "oracle" / "gbarecomp_oracle.exe"
+BIOS_SMOKE = ROOT / "build" / exe_name("bios_smoke")
+ORACLE = ROOT / "build" / "oracle" / exe_name("gbarecomp_oracle")
 BIOS_PATH = "bios/gba_bios.bin"
 
 

--- a/oracle/diff_cart.py
+++ b/oracle/diff_cart.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""diff_cart.py — same-instant native-vs-oracle comparison for a CARTRIDGE run.
+
+find_first_diverge.py compares BIOS execution: it drives bios_smoke and never
+passes --rom, so it cannot say anything about a game. This is its cartridge
+sibling. Both sides boot the same ROM, are advanced to the same VBlank count
+(hardware event, per the SYNC RULES — never a raw frame index), and then their
+PAL / VRAM / OAM / IO are compared byte-for-byte.
+
+The point is to separate two failures that look identical on screen:
+
+    regions match, pixels differ  -> our COMPOSITOR is wrong
+    regions differ                -> guest EXECUTION diverged first, and the
+                                     picture is downstream of that
+
+Usage:
+    python oracle/diff_cart.py --rom path/to/game.gba --frame 700
+    python oracle/diff_cart.py --rom game.gba --scan 100 1200 100
+
+`--scan lo hi step` walks VBlank counts and reports the first one that differs,
+which is usually what you actually want: the earliest divergence is the only one
+with a root cause.
+
+IMPORTANT for RTC carts (Boktai, Pokémon Ruby/Sapphire/Emerald, ...): the two
+processes read the clock independently, so a bare comparison can report a
+"divergence" that is only a difference in wall time. Pin ours with
+RECOMP_RTC_EPOCH and be aware the oracle side still follows host time; treat any
+day/night-dependent difference as uncontrolled unless both clocks are fixed.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import socket
+import subprocess
+import sys
+import time
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "oracle"))
+from recomp_paths import exe_name, recomp_exe  # noqa: E402
+
+ORACLE = ROOT / "build" / "oracle" / exe_name("gbarecomp_oracle")
+BIOS = ROOT / "bios" / "gba_bios.bin"
+
+# Region name -> (command pair, base address, byte length).
+REGIONS = [
+    ("PAL",   "read_pal",   "read_emu_pal",   0x05000000, 0x400),
+    ("OAM",   "read_oam",   "read_emu_oam",   0x07000000, 0x400),
+    ("VRAM",  "read_vram",  "read_emu_vram",  0x06000000, 0x18000),
+    ("IWRAM", "read_iwram", "read_emu_iwram", 0x03000000, 0x8000),
+]
+
+# Display / blend / window registers, reported on a mismatch because they are
+# what usually explains a pixel difference when the regions agree.
+IO_REGS = [
+    (0x04000000, "DISPCNT"), (0x04000008, "BG0CNT"), (0x0400000A, "BG1CNT"),
+    (0x0400000C, "BG2CNT"), (0x0400000E, "BG3CNT"), (0x04000048, "WININ"),
+    (0x0400004A, "WINOUT"), (0x04000050, "BLDCNT"), (0x04000052, "BLDALPHA"),
+    (0x04000054, "BLDY"),
+]
+
+
+class Client:
+    def __init__(self, port: int, timeout: float = 30.0):
+        deadline = time.time() + timeout
+        self.sock = None
+        last: Exception | None = None
+        while time.time() < deadline:
+            try:
+                self.sock = socket.create_connection(("127.0.0.1", port), timeout=2.0)
+                break
+            except OSError as e:
+                last = e
+                time.sleep(0.2)
+        if self.sock is None:
+            raise RuntimeError(f"cannot reach 127.0.0.1:{port}: {last}")
+        self.sock.settimeout(600.0)
+        self.buf = b""
+
+    def call(self, **kw) -> dict:
+        self.sock.sendall(json.dumps(kw).encode() + b"\n")
+        while b"\n" not in self.buf:
+            chunk = self.sock.recv(1 << 20)
+            if not chunk:
+                raise RuntimeError("peer closed the connection")
+            self.buf += chunk
+        line, _, self.buf = self.buf.partition(b"\n")
+        return json.loads(line.decode())
+
+    def close(self) -> None:
+        for fn in (lambda: self.call(cmd="quit"), self.sock.close):
+            try:
+                fn()
+            except Exception:
+                pass
+
+
+def hexbytes(d: str) -> bytes:
+    return bytes.fromhex(d)
+
+
+def read_hw(cli: Client, cmd: str, addr: int) -> int:
+    r = cli.call(cmd=cmd, addr=addr, len=2)
+    d = r["data"]
+    return int(d[0:2], 16) | (int(d[2:4], 16) << 8)
+
+
+def compare(native: Client, oracle: Client) -> list[tuple[str, int, int]]:
+    """Return [(region, differing_bytes, total)] for regions that differ."""
+    out = []
+    for name, ncmd, ocmd, base, ln in REGIONS:
+        a = hexbytes(native.call(cmd=ncmd, addr=base, len=ln)["data"])
+        b = hexbytes(oracle.call(cmd=ocmd, addr=base, len=ln)["data"])
+        n = sum(1 for i in range(min(len(a), len(b))) if a[i] != b[i])
+        if n:
+            out.append((name, n, ln))
+    return out
+
+
+def advance(native: Client, oracle: Client, by: int) -> None:
+    native.call(cmd="run_frames", n=by)
+    for _ in range(by):
+        oracle.call(cmd="emu_step_to_vblank")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--rom", required=True)
+    ap.add_argument("--bios", default=str(BIOS))
+    ap.add_argument("--frame", type=int, help="compare once at this VBlank count")
+    ap.add_argument("--scan", type=int, nargs=3, metavar=("LO", "HI", "STEP"),
+                    help="walk VBlank counts and stop at the first difference")
+    ap.add_argument("--native-exe", default=None,
+                    help="game executable (default: resolved via recomp_paths)")
+    ap.add_argument("--native-port", type=int, default=19842)
+    ap.add_argument("--oracle-port", type=int, default=19843)
+    a = ap.parse_args()
+
+    if not a.frame and not a.scan:
+        a.frame = 600
+    native_exe = pathlib.Path(a.native_exe) if a.native_exe else recomp_exe(ROOT)
+    for p, what in ((ORACLE, "oracle binary"), (native_exe, "game executable"),
+                    (pathlib.Path(a.bios), "BIOS"), (pathlib.Path(a.rom), "ROM")):
+        if not p.exists():
+            print(f"missing {what}: {p}")
+            return 2
+
+    procs = []
+    n = o = None
+    try:
+        procs.append(subprocess.Popen(
+            [str(native_exe), "--bios", a.bios, "--rom", a.rom,
+             "--tcp", str(a.native_port)],
+            cwd=str(native_exe.parent.parent), env=dict(os.environ),
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL))
+        procs.append(subprocess.Popen(
+            [str(ORACLE), "--bios", a.bios, "--rom", a.rom,
+             "--port", str(a.oracle_port)],
+            cwd=str(ROOT),
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL))
+        n = Client(a.native_port)
+        o = Client(a.oracle_port)
+
+        targets = ([a.frame] if a.frame
+                   else list(range(a.scan[0], a.scan[1] + 1, a.scan[2])))
+        cur = 0
+        for want in targets:
+            advance(n, o, want - cur)
+            cur = want
+            diffs = compare(n, o)
+            if not diffs:
+                print(f"vblank {want:>6}: identical "
+                      f"({', '.join(r[0] for r in REGIONS)})")
+                continue
+            print(f"\nvblank {want}: DIVERGED")
+            for name, cnt, total in diffs:
+                print(f"    {name}: {cnt} / {total} bytes differ")
+            print("  display/blend/window registers at this instant:")
+            for addr, label in IO_REGS:
+                nv = read_hw(n, "read_io", addr)
+                ov = read_hw(o, "read_emu_io", addr)
+                flag = "  <-- differs" if nv != ov else ""
+                print(f"    {label:9} ours=0x{nv:04X} oracle=0x{ov:04X}{flag}")
+            names = {d[0] for d in diffs}
+            if names <= {"PAL"}:
+                print("\n  Only PAL differs — suspect palette writes, not geometry.")
+            elif "OAM" in names or "VRAM" in names:
+                print("\n  VRAM/OAM differ, so guest EXECUTION diverged before "
+                      "rendering.\n  The compositor is not implicated by this "
+                      "result.")
+            return 1
+        print("\nno divergence found across the requested points")
+        return 0
+    finally:
+        for c in (n, o):
+            if c:
+                c.close()
+        for p in procs:
+            p.terminate()
+            try:
+                p.wait(timeout=5)
+            except Exception:
+                p.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/oracle/diff_counters.py
+++ b/oracle/diff_counters.py
@@ -26,9 +26,12 @@ import argparse, json, pathlib, socket, subprocess, sys, time
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent          # gbarecomp/
 import recomp_paths as _rp
+import sys as _sys, pathlib as _pl
+_sys.path.insert(0, str(_pl.Path(__file__).resolve().parent))
+from recomp_paths import exe_name
 PROJ = _rp.game_dir(ROOT)
 RECOMP_EXE = _rp.recomp_exe(ROOT)
-INTERP_EXE = ROOT / "build" / "bios_smoke.exe"
+INTERP_EXE = ROOT / "build" / exe_name("bios_smoke")
 BIOS = ROOT / "bios" / "gba_bios.bin"
 ROM = PROJ / "roms" / "minishcap_usa.gba"
 DEF_STATE = PROJ / "roms" / "minishcap_usa.state3"

--- a/oracle/diff_cycle_trace.py
+++ b/oracle/diff_cycle_trace.py
@@ -31,9 +31,12 @@ import argparse, json, os, pathlib, socket, struct, subprocess, sys, time
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent          # gbarecomp/
 import recomp_paths as _rp
+import sys as _sys, pathlib as _pl
+_sys.path.insert(0, str(_pl.Path(__file__).resolve().parent))
+from recomp_paths import exe_name
 PROJ = _rp.game_dir(ROOT)
 RECOMP_EXE = _rp.recomp_exe(ROOT)
-INTERP_EXE = ROOT / "build" / "bios_smoke.exe"
+INTERP_EXE = ROOT / "build" / exe_name("bios_smoke")
 BIOS = ROOT / "bios" / "gba_bios.bin"
 ROM = PROJ / "roms" / "minishcap_usa.gba"
 OUT = ROOT / "oracle" / "trace_out"

--- a/oracle/diff_frame.py
+++ b/oracle/diff_frame.py
@@ -21,6 +21,9 @@ from __future__ import annotations
 import argparse
 import json
 import pathlib
+import sys as _sys, pathlib as _pl
+_sys.path.insert(0, str(_pl.Path(__file__).resolve().parent))
+from recomp_paths import exe_name
 import socket
 import subprocess
 import sys
@@ -28,8 +31,8 @@ import time
 from typing import Iterable, Optional
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
-BIOS_SMOKE = ROOT / "build" / "bios_smoke.exe"
-ORACLE     = ROOT / "build" / "oracle" / "gbarecomp_oracle.exe"
+BIOS_SMOKE = ROOT / "build" / exe_name("bios_smoke")
+ORACLE     = ROOT / "build" / "oracle" / exe_name("gbarecomp_oracle")
 BIOS_PATH  = "bios/gba_bios.bin"
 
 # Region descriptors: (key, display name, byte size, native-cmd, oracle-cmd).

--- a/oracle/diff_interp.py
+++ b/oracle/diff_interp.py
@@ -20,6 +20,9 @@ from __future__ import annotations
 
 import argparse
 import pathlib
+import sys as _sys, pathlib as _pl
+_sys.path.insert(0, str(_pl.Path(__file__).resolve().parent))
+from recomp_paths import exe_name
 import socket
 import subprocess
 import sys
@@ -29,7 +32,7 @@ from diff_m4a import (JsonClient, spawn, coalesce_diffs,  # noqa: E402
                       NATIVE_EXE, BIOS_PATH, ROM_PATH, PROJ, ROOT)
 from diff_intro import held_this_frame, START_KEYINPUT, NONE_KEYINPUT  # noqa: E402
 
-BIOS_SMOKE = ROOT / "build" / "bios_smoke.exe"
+BIOS_SMOKE = ROOT / "build" / exe_name("bios_smoke")
 
 
 def main() -> int:

--- a/oracle/diff_io.py
+++ b/oracle/diff_io.py
@@ -17,9 +17,12 @@ import argparse, json, pathlib, socket, subprocess, sys, time
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 import recomp_paths as _rp
+import sys as _sys, pathlib as _pl
+_sys.path.insert(0, str(_pl.Path(__file__).resolve().parent))
+from recomp_paths import exe_name
 PROJ = _rp.game_dir(ROOT)
 RECOMP_EXE = _rp.recomp_exe(ROOT)
-INTERP_EXE = ROOT / "build" / "bios_smoke.exe"
+INTERP_EXE = ROOT / "build" / exe_name("bios_smoke")
 BIOS = ROOT / "bios" / "gba_bios.bin"
 ROM = PROJ / "roms" / "minishcap_usa.gba"
 DEF_STATE = PROJ / "roms" / "minishcap_usa.state3"

--- a/oracle/diff_iwram.py
+++ b/oracle/diff_iwram.py
@@ -23,9 +23,12 @@ import argparse, json, pathlib, socket, subprocess, sys, time
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 import recomp_paths as _rp
+import sys as _sys, pathlib as _pl
+_sys.path.insert(0, str(_pl.Path(__file__).resolve().parent))
+from recomp_paths import exe_name
 PROJ = _rp.game_dir(ROOT)
 RECOMP_EXE = _rp.recomp_exe(ROOT)
-INTERP_EXE = ROOT / "build" / "bios_smoke.exe"
+INTERP_EXE = ROOT / "build" / exe_name("bios_smoke")
 BIOS = ROOT / "bios" / "gba_bios.bin"
 ROM = PROJ / "roms" / "minishcap_usa.gba"
 DEF_STATE = PROJ / "roms" / "minishcap_usa.state3"

--- a/oracle/diff_m4a.py
+++ b/oracle/diff_m4a.py
@@ -25,6 +25,9 @@ from __future__ import annotations
 import argparse
 import json
 import pathlib
+import sys as _sys, pathlib as _pl
+_sys.path.insert(0, str(_pl.Path(__file__).resolve().parent))
+from recomp_paths import exe_name
 import socket
 import subprocess
 import sys
@@ -35,7 +38,7 @@ ROOT = pathlib.Path(__file__).resolve().parent.parent          # gbarecomp/
 import recomp_paths as _rp
 PROJ = _rp.game_dir(ROOT)
 NATIVE_EXE = _rp.recomp_exe(ROOT)
-ORACLE     = ROOT / "build" / "oracle" / "gbarecomp_oracle.exe"
+ORACLE     = ROOT / "build" / "oracle" / exe_name("gbarecomp_oracle")
 BIOS_PATH  = ROOT / "bios" / "gba_bios.bin"
 ROM_PATH   = PROJ / "roms" / "minishcap_usa.gba"
 DEF_STATE  = PROJ / "roms" / "minishcap_usa.state3"

--- a/oracle/dual_drive.py
+++ b/oracle/dual_drive.py
@@ -13,13 +13,16 @@ Set the log env vars before running, e.g.:
 """
 from __future__ import annotations
 import argparse, json, os, pathlib, socket, subprocess, sys, time
+import sys as _sys, pathlib as _pl
+_sys.path.insert(0, str(_pl.Path(__file__).resolve().parent))
+from recomp_paths import exe_name
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 PROJ = ROOT.parent / "MinishCapRecomp"
 RECOMP_EXE = pathlib.Path(os.environ.get(
-    "GBARECOMP_RECOMP_EXE", PROJ / "build" / "MinishCapRecomp.exe"))
+    "GBARECOMP_RECOMP_EXE", PROJ / "build" / exe_name("MinishCapRecomp")))
 INTERP_EXE = pathlib.Path(os.environ.get(
-    "GBARECOMP_INTERP_EXE", ROOT / "build" / "bios_smoke.exe"))
+    "GBARECOMP_INTERP_EXE", ROOT / "build" / exe_name("bios_smoke")))
 BIOS = ROOT / "bios" / "gba_bios.bin"
 ROM = PROJ / "roms" / "minishcap_usa.gba"
 START_KEYINPUT = 0x3F7

--- a/oracle/dump_regions.py
+++ b/oracle/dump_regions.py
@@ -15,9 +15,12 @@ import argparse, json, pathlib, socket, subprocess, time
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 import recomp_paths as _rp
+import sys as _sys, pathlib as _pl
+_sys.path.insert(0, str(_pl.Path(__file__).resolve().parent))
+from recomp_paths import exe_name
 PROJ = _rp.game_dir(ROOT)
 RECOMP_EXE = _rp.recomp_exe(ROOT)
-INTERP_EXE = ROOT / "build" / "bios_smoke.exe"
+INTERP_EXE = ROOT / "build" / exe_name("bios_smoke")
 BIOS = ROOT / "bios" / "gba_bios.bin"
 ROM = PROJ / "roms" / "minishcap_usa.gba"
 STATE = PROJ / "roms" / "minishcap_usa.state3"

--- a/oracle/find_first_diverge.py
+++ b/oracle/find_first_diverge.py
@@ -21,6 +21,9 @@ from __future__ import annotations
 import argparse
 import json
 import pathlib
+import sys as _sys, pathlib as _pl
+_sys.path.insert(0, str(_pl.Path(__file__).resolve().parent))
+from recomp_paths import exe_name
 import socket
 import subprocess
 import sys
@@ -28,8 +31,8 @@ import time
 from typing import Optional
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
-BIOS_SMOKE = ROOT / "build" / "bios_smoke.exe"
-ORACLE     = ROOT / "build" / "oracle" / "gbarecomp_oracle.exe"
+BIOS_SMOKE = ROOT / "build" / exe_name("bios_smoke")
+ORACLE     = ROOT / "build" / "oracle" / exe_name("gbarecomp_oracle")
 
 
 class JsonClient:

--- a/oracle/fp_cycle_diff.py
+++ b/oracle/fp_cycle_diff.py
@@ -19,13 +19,16 @@ divergence (MC-HP-002: divergence at f682, so --frame 682).
 """
 from __future__ import annotations
 import argparse, json, os, pathlib, socket, struct, subprocess, sys, time
+import sys as _sys, pathlib as _pl
+_sys.path.insert(0, str(_pl.Path(__file__).resolve().parent))
+from recomp_paths import exe_name
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 PROJ = ROOT.parent / "MinishCapRecomp"
 RECOMP_EXE = pathlib.Path(os.environ.get(
-    "GBARECOMP_RECOMP_EXE", PROJ / "build" / "MinishCapRecomp.exe"))
+    "GBARECOMP_RECOMP_EXE", PROJ / "build" / exe_name("MinishCapRecomp")))
 INTERP_EXE = pathlib.Path(os.environ.get(
-    "GBARECOMP_INTERP_EXE", ROOT / "build" / "bios_smoke.exe"))
+    "GBARECOMP_INTERP_EXE", ROOT / "build" / exe_name("bios_smoke")))
 BIOS = ROOT / "bios" / "gba_bios.bin"
 ROM = PROJ / "roms" / "minishcap_usa.gba"
 OUT = ROOT / "oracle" / "trace_out"

--- a/oracle/inst_per_frame.py
+++ b/oracle/inst_per_frame.py
@@ -16,6 +16,9 @@ from __future__ import annotations
 import argparse
 import json
 import pathlib
+import sys as _sys, pathlib as _pl
+_sys.path.insert(0, str(_pl.Path(__file__).resolve().parent))
+from recomp_paths import exe_name
 import socket
 import subprocess
 import sys
@@ -23,8 +26,8 @@ import time
 from typing import Optional
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
-BIOS_SMOKE = ROOT / "build" / "bios_smoke.exe"
-ORACLE     = ROOT / "build" / "oracle" / "gbarecomp_oracle.exe"
+BIOS_SMOKE = ROOT / "build" / exe_name("bios_smoke")
+ORACLE     = ROOT / "build" / "oracle" / exe_name("gbarecomp_oracle")
 
 
 class JsonClient:

--- a/oracle/mem_diff.py
+++ b/oracle/mem_diff.py
@@ -15,13 +15,16 @@ Drives the diff_intro START pulse to --frame on both, reads IWRAM (32K) and, wit
 """
 from __future__ import annotations
 import argparse, json, os, pathlib, socket, subprocess, sys, time
+import sys as _sys, pathlib as _pl
+_sys.path.insert(0, str(_pl.Path(__file__).resolve().parent))
+from recomp_paths import exe_name
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 PROJ = ROOT.parent / "MinishCapRecomp"
 RECOMP_EXE = pathlib.Path(os.environ.get(
-    "GBARECOMP_RECOMP_EXE", PROJ / "build" / "MinishCapRecomp.exe"))
+    "GBARECOMP_RECOMP_EXE", PROJ / "build" / exe_name("MinishCapRecomp")))
 INTERP_EXE = pathlib.Path(os.environ.get(
-    "GBARECOMP_INTERP_EXE", ROOT / "build" / "bios_smoke.exe"))
+    "GBARECOMP_INTERP_EXE", ROOT / "build" / exe_name("bios_smoke")))
 BIOS = ROOT / "bios" / "gba_bios.bin"
 ROM = PROJ / "roms" / "minishcap_usa.gba"
 START_KEYINPUT = 0x3F7

--- a/oracle/phase_probe.py
+++ b/oracle/phase_probe.py
@@ -20,9 +20,12 @@ import json, pathlib, socket, subprocess, sys, time
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 import recomp_paths as _rp
+import sys as _sys, pathlib as _pl
+_sys.path.insert(0, str(_pl.Path(__file__).resolve().parent))
+from recomp_paths import exe_name
 PROJ = _rp.game_dir(ROOT)
 RECOMP_EXE = _rp.recomp_exe(ROOT)
-INTERP_EXE = ROOT / "build" / "bios_smoke.exe"
+INTERP_EXE = ROOT / "build" / exe_name("bios_smoke")
 BIOS = ROOT / "bios" / "gba_bios.bin"
 ROM = PROJ / "roms" / "minishcap_usa.gba"
 STATE = PROJ / "roms" / "minishcap_usa.state3"

--- a/oracle/recomp_paths.py
+++ b/oracle/recomp_paths.py
@@ -23,6 +23,17 @@ import os
 import pathlib
 
 
+def exe_name(stem: str) -> str:
+    """Executable filename for the host platform.
+
+    The oracle scripts were written on Windows and hardcoded a `.exe` suffix, so
+    none of them could find bios_smoke / gbarecomp_oracle / the game binary on
+    macOS or Linux — where CMake emits no suffix. Route every executable name
+    through here instead.
+    """
+    return stem + (".exe" if os.name == "nt" else "")
+
+
 def game_dir(root: pathlib.Path) -> pathlib.Path:
     env = os.environ.get("GBARECOMP_GAME_DIR")
     if env:
@@ -37,4 +48,4 @@ def recomp_exe(root: pathlib.Path) -> pathlib.Path:
     env = os.environ.get("GBARECOMP_RECOMP_EXE")
     if env:
         return pathlib.Path(env)
-    return game_dir(root) / "build" / "MinishCapRecomp.exe"
+    return game_dir(root) / "build" / exe_name("MinishCapRecomp")

--- a/oracle/spin_mem_diff.py
+++ b/oracle/spin_mem_diff.py
@@ -15,11 +15,14 @@ written it. Pure observation.
 """
 from __future__ import annotations
 import argparse, json, os, pathlib, socket, subprocess, sys, time
+import sys as _sys, pathlib as _pl
+_sys.path.insert(0, str(_pl.Path(__file__).resolve().parent))
+from recomp_paths import exe_name
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 PROJ = ROOT.parent / "MinishCapRecomp"
-REC = os.environ.get("GBARECOMP_RECOMP_EXE", str(PROJ / "build" / "MinishCapRecomp.exe"))
-INT = os.environ.get("GBARECOMP_INTERP_EXE", str(ROOT / "build" / "bios_smoke.exe"))
+REC = os.environ.get("GBARECOMP_RECOMP_EXE", str(PROJ / "build" / exe_name("MinishCapRecomp")))
+INT = os.environ.get("GBARECOMP_INTERP_EXE", str(ROOT / "build" / exe_name("bios_smoke")))
 BIOS = str(ROOT / "bios" / "gba_bios.bin")
 ROM = str(PROJ / "roms" / "minishcap_usa.gba")
 FRAME_CYC = 280896

--- a/oracle/track_bytes.py
+++ b/oracle/track_bytes.py
@@ -13,9 +13,12 @@ import argparse, json, pathlib, socket, subprocess, time
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 import recomp_paths as _rp
+import sys as _sys, pathlib as _pl
+_sys.path.insert(0, str(_pl.Path(__file__).resolve().parent))
+from recomp_paths import exe_name
 PROJ = _rp.game_dir(ROOT)
 RECOMP_EXE = _rp.recomp_exe(ROOT)
-INTERP_EXE = ROOT / "build" / "bios_smoke.exe"
+INTERP_EXE = ROOT / "build" / exe_name("bios_smoke")
 BIOS = ROOT / "bios" / "gba_bios.bin"
 ROM = PROJ / "roms" / "minishcap_usa.gba"
 STATE = PROJ / "roms" / "minishcap_usa.state3"

--- a/oracle/watch_addrs.py
+++ b/oracle/watch_addrs.py
@@ -8,9 +8,12 @@ import json, pathlib, socket, subprocess, sys, time
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 import recomp_paths as _rp
+import sys as _sys, pathlib as _pl
+_sys.path.insert(0, str(_pl.Path(__file__).resolve().parent))
+from recomp_paths import exe_name
 PROJ = _rp.game_dir(ROOT)
 RECOMP_EXE = _rp.recomp_exe(ROOT)
-INTERP_EXE = ROOT / "build" / "bios_smoke.exe"
+INTERP_EXE = ROOT / "build" / exe_name("bios_smoke")
 BIOS = ROOT / "bios" / "gba_bios.bin"
 ROM = PROJ / "roms" / "minishcap_usa.gba"
 STATE = PROJ / "roms" / "minishcap_usa.state3"

--- a/oracle/wp_drive.py
+++ b/oracle/wp_drive.py
@@ -18,11 +18,14 @@ Usage:
 """
 from __future__ import annotations
 import argparse, json, os, pathlib, socket, subprocess, sys, time
+import sys as _sys, pathlib as _pl
+_sys.path.insert(0, str(_pl.Path(__file__).resolve().parent))
+from recomp_paths import exe_name
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 PROJ = ROOT.parent / "MinishCapRecomp"
 RECOMP_EXE = pathlib.Path(os.environ.get(
-    "GBARECOMP_RECOMP_EXE", PROJ / "build" / "MinishCapRecomp.exe"))
+    "GBARECOMP_RECOMP_EXE", PROJ / "build" / exe_name("MinishCapRecomp")))
 START_KEYINPUT = 0x3F7
 NONE_KEYINPUT = 0x3FF
 

--- a/src/gba/gba_bus.h
+++ b/src/gba/gba_bus.h
@@ -22,6 +22,7 @@
 #include "gba_memory.h"
 #include "gba_gpio.h"
 #include "gba_gyro.h"
+#include "gba_solar.h"
 #include "gba_rtc.h"
 #include "gba_save.h"
 
@@ -115,6 +116,11 @@ public:
         gpio_.attach(&rtc_);   // idempotent; further devices attach here
         gyro_.configure(rom_bytes, rom_size);
         gpio_.attach(&gyro_);
+        // Boktai's solar sensor shares those same four pins with the clock,
+        // arbitrating on pin 2 (the RTC's chip select). It has no ROM
+        // signature to detect, so it is an explicit per-game opt-in.
+        solar_.configure(solar_enabled_);
+        gpio_.attach(&solar_);
         // Arm the MP2K audio shadow mixer (QoL; off unless the ROM links
         // MP2K and it's requested via [audio].shadow / GBARECOMP_AUDIO_SHADOW).
         // The region pointers back its side-effect-free MemView.
@@ -148,6 +154,10 @@ public:
 
     GbaGyro&       gyro()       { return gyro_; }
     const GbaGyro& gyro() const { return gyro_; }
+    GbaSolarSensor&       solar()       { return solar_; }
+    const GbaSolarSensor& solar() const { return solar_; }
+    // Must be set before set_rom(); the sensor is opt-in per game.
+    void set_solar_enabled(bool on) { solar_enabled_ = on; }
 
 
     // Region accessors — useful for tests, debug snapshots, and the
@@ -250,8 +260,10 @@ private:
     GbaAudio    audio_;
     GbaSave     save_;
     GbaRtc      rtc_;
-    GbaGyro     gyro_;
-    GpioPort    gpio_;
+    GbaGyro        gyro_;
+    GpioPort       gpio_;
+    GbaSolarSensor solar_;
+    bool           solar_enabled_ = false;
 
     uint32_t    last_fetched_   = 0;
     std::size_t unmapped_count_ = 0;

--- a/src/gba/gba_solar.cpp
+++ b/src/gba/gba_solar.cpp
@@ -1,0 +1,72 @@
+// gba_solar.cpp — see gba_solar.h.
+
+#include "gba_solar.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace gba {
+
+void GbaSolarSensor::configure(bool enable) {
+    active_ = enable && (std::getenv("RECOMP_SOLAR_OFF") == nullptr);
+    counter_ = 0;
+    threshold_ = 0xFF;
+    prev_clock_low_ = false;
+    selected_ = false;
+    have_fixed_ = false;
+    fixed_ = 0;
+
+    if (const char* e = std::getenv("RECOMP_SOLAR_FIXED")) {
+        char* end = nullptr;
+        const long v = std::strtol(e, &end, 0);
+        if (end != e && v >= 0 && v <= 255) {
+            have_fixed_ = true;
+            fixed_ = static_cast<uint8_t>(v);
+        }
+    }
+    if (active_) {
+        std::printf("solar_sensor=ENABLED%s\n",
+                    have_fixed_ ? " (RECOMP_SOLAR_FIXED pinned)" : "");
+    }
+}
+
+uint8_t GbaSolarSensor::sample_threshold() {
+    if (have_fixed_)  return brightness_to_threshold(fixed_);
+    if (provider_)    return brightness_to_threshold(provider_());
+    // No host light source attached: darkest possible, comparator never trips.
+    return 0xFF;
+}
+
+void GbaSolarSensor::gpio_write(uint8_t pins) {
+    // Pin 2 is the RTC's chip select. While it is asserted the clock owns the
+    // port and this device must not touch the wires at all.
+    selected_ = (pins & kPinSelect) == 0;
+    if (!selected_) return;
+
+    // Reset: zero the counter and latch exactly one light sample, which is the
+    // threshold this conversion compares against.
+    if (pins & kPinReset) {
+        counter_ = 0;
+        // Preset "previous clock was low" so the first rising edge after a
+        // reset counts. (mGBA marks level-vs-edge triggering here as
+        // unverified; we match its level-triggered behaviour. If readings look
+        // sticky or quantised, this is the first thing to vary.)
+        prev_clock_low_ = true;
+        threshold_ = sample_threshold();
+    }
+
+    // ADC clock: advance on the rising edge.
+    const bool clock_high = (pins & kPinClock) != 0;
+    if (clock_high && prev_clock_low_) {
+        counter_ = static_cast<uint16_t>((counter_ + 1u) & kCounterMask);
+    }
+    prev_clock_low_ = !clock_high;
+}
+
+int GbaSolarSensor::gpio_drive(uint8_t bit) const {
+    // Only the comparator pin, and only while the RTC is not holding the bus.
+    if (bit != kPinOut || !selected_) return -1;
+    return comparator() ? 1 : 0;
+}
+
+}  // namespace gba

--- a/src/gba/gba_solar.h
+++ b/src/gba/gba_solar.h
@@ -1,0 +1,101 @@
+// gba_solar.h — Boktai cartridge solar sensor (photodiode + integrating ADC).
+//
+// Device emulation, not HLE: the guest's own driver bit-bangs the conversion
+// and counts clocks, exactly as it would against the real chip. Used by the
+// Boktai / Bokura no Taiyou line, which carries this sensor AND the S-3511A RTC
+// on the same four GPIO pins.
+//
+// ── Pin map (bits of the GPIO data port at 0x080000C4) ───────────────
+//   0  ADC clock  — the counter advances on the rising edge
+//   1  reset      — zeroes the counter and latches one light sample
+//   2  chip select (the RTC's CS) — while HIGH the clock owns the bus and this
+//      device stays off the wires entirely. This is how the two chips share
+//      the port: exactly one is live at a time.
+//   3  comparator output — driven high once counter >= threshold
+//
+// ── Protocol ─────────────────────────────────────────────────────────
+// It reports light as a *time*, not a value. The guest resets, then pulses the
+// clock and counts how many pulses pass before pin 3 flips. Fewer clocks means
+// more light.
+//
+// ── The value is inverted ────────────────────────────────────────────
+// Because the latched sample is a *threshold*, a SMALL threshold trips the
+// comparator SOONER. So 0x00 is the brightest reading and 0xFF the darkest; an
+// unlit / absent sensor sits at 0xFF and effectively never trips. Providers
+// speak in ordinary brightness (0 = dark, 255 = bright) and the conversion is
+// funnelled through one named function so the polarity cannot be flipped by
+// accident — getting it backwards would make sunlight read as midnight.
+//
+// ── Sourcing ─────────────────────────────────────────────────────────
+// Pin assignment and comparator behaviour were read from mGBA's
+// src/gba/cart/gpio.c (_lightReadPins) as a HARDWARE REFERENCE only; no code is
+// derived from it. mGBA is MPL-2.0 and third_party/README.md requires the
+// native build to carry no copyleft emulator dependencies, while
+// docs/ARCHITECTURE.md explicitly permits borrowing "hardware reference
+// behavior from emulators and hardware docs".
+
+#pragma once
+
+#include <cstdint>
+
+#include "gba_gpio.h"
+
+namespace gba {
+
+class GbaSolarSensor final : public GpioDevice {
+public:
+    // Returns ordinary brightness: 0 = pitch dark, 255 = full sun.
+    using LightProvider = uint8_t (*)();
+
+    // The sensor cannot be detected from the ROM the way the RTC can (there is
+    // no library signature for it), so it is an explicit opt-in per game.
+    // Honors RECOMP_SOLAR_OFF, and RECOMP_SOLAR_FIXED=<0-255> pins a constant
+    // brightness for deterministic runs — the same shape as RECOMP_RTC_EPOCH.
+    void configure(bool enable);
+
+    bool active() const { return active_; }
+
+    // Host light source. Null means "no sensor illuminated": the threshold
+    // stays at its darkest and the comparator never trips.
+    void set_provider(LightProvider p) { provider_ = p; }
+
+    // ── GpioDevice ───────────────────────────────────────────────────
+    bool gpio_active() const override { return active_; }
+    void gpio_write(uint8_t pins) override;
+    int  gpio_drive(uint8_t bit) const override;
+
+    // Introspection for tests and the on-screen light meter.
+    uint16_t counter() const { return counter_; }
+    uint8_t  threshold() const { return threshold_; }
+    bool     comparator() const { return counter_ >= threshold_; }
+
+    // The single place the polarity flip lives.
+    static uint8_t brightness_to_threshold(uint8_t brightness) {
+        return static_cast<uint8_t>(255u - brightness);
+    }
+
+private:
+    uint8_t sample_threshold();
+
+    static constexpr uint8_t kPinClock  = 0x1;
+    static constexpr uint8_t kPinReset  = 0x2;
+    static constexpr uint8_t kPinSelect = 0x4;   // RTC chip select
+    static constexpr uint8_t kPinOut    = 3;     // bit index
+    static constexpr uint16_t kCounterMask = 0x0FFF;   // 12-bit counter
+
+    bool          active_   = false;
+    LightProvider provider_ = nullptr;
+
+    uint16_t counter_   = 0;
+    uint8_t  threshold_ = 0xFF;   // darkest until a sample is latched
+    // Tracks whether the previous clock level was LOW, so a rising edge can be
+    // detected. Reset presets it true, matching the reference implementation.
+    bool prev_clock_low_ = false;
+    // The sensor only drives its output pin while selected (CS low).
+    bool selected_ = false;
+
+    bool    have_fixed_ = false;   // RECOMP_SOLAR_FIXED override
+    uint8_t fixed_      = 0;
+};
+
+}  // namespace gba

--- a/src/runtime/host_window.cpp
+++ b/src/runtime/host_window.cpp
@@ -64,6 +64,7 @@ enum HostHotkey {
     HK_FULLSCREEN = 0, HK_PAUSE, HK_TURBO,
     HK_WINDOW_BIGGER, HK_WINDOW_SMALLER,
     HK_VOLUME_UP, HK_VOLUME_DOWN, HK_DISPLAY_PERF,
+    HK_SOLAR_BRIGHTER, HK_SOLAR_DIMMER, HK_SOLAR_LIVE,
     HK_COUNT
 };
 
@@ -574,11 +575,13 @@ const char* const kHotkeyNames[HK_COUNT] = {
     "Fullscreen", "Pause", "Turbo",
     "WindowBigger", "WindowSmaller",
     "VolumeUp", "VolumeDown", "DisplayPerf",
+    "SolarBrighter", "SolarDimmer", "SolarLive",
 };
 const char* const kHotkeyDefaults[HK_COUNT] = {
     "Alt+Return", "Shift+P", "Tab",
     "", "",
     "", "", "F",
+    "", "", "",
 };
 
 // SDL_GetScancodeFromName plus the same lowercase aliases recomp-ui's
@@ -1550,16 +1553,6 @@ HostWindow::Events HostWindow::pump() {
             Uint16 mods = e.key.keysym.mod;
             if (sym == SDLK_ESCAPE) {
                 ev.quit = true;
-            } else if (sym >= SDLK_1 && sym <= SDLK_9 &&
-                       !(mods & (KMOD_SHIFT | KMOD_CTRL | KMOD_ALT))) {
-                // Solar-sensor debug level. The number row deliberately, since
-                // F1..F9 are already the save-state slots.
-                ev.solar_step = static_cast<int>(sym - SDLK_1) + 1;
-            } else if (sym == SDLK_0 &&
-                       !(mods & (KMOD_SHIFT | KMOD_CTRL | KMOD_ALT))) {
-                // 0 releases the override rather than meaning "level 0" —
-                // level 0 is already reachable as key 1 (brightness 0).
-                ev.solar_step = -1;
             } else if (sym >= SDLK_F1 && sym <= SDLK_F9) {
                 int slot = static_cast<int>(sym - SDLK_F1) + 1;
                 if (mods & KMOD_SHIFT) ev.save_slot = slot;
@@ -1580,6 +1573,9 @@ HostWindow::Events HostWindow::pump() {
                         case HK_VOLUME_UP:      ev.volume_up = true;         break;
                         case HK_VOLUME_DOWN:    ev.volume_down = true;       break;
                         case HK_DISPLAY_PERF:   ev.toggle_fps = true;        break;
+                        case HK_SOLAR_BRIGHTER: ev.solar_brighter = true;    break;
+                        case HK_SOLAR_DIMMER:   ev.solar_dimmer = true;      break;
+                        case HK_SOLAR_LIVE:     ev.solar_live = true;        break;
                     }
                 }
             }

--- a/src/runtime/host_window.cpp
+++ b/src/runtime/host_window.cpp
@@ -1550,6 +1550,11 @@ HostWindow::Events HostWindow::pump() {
             Uint16 mods = e.key.keysym.mod;
             if (sym == SDLK_ESCAPE) {
                 ev.quit = true;
+            } else if (sym >= SDLK_1 && sym <= SDLK_9 &&
+                       !(mods & (KMOD_SHIFT | KMOD_CTRL | KMOD_ALT))) {
+                // Solar-sensor debug level. The number row deliberately, since
+                // F1..F9 are already the save-state slots.
+                ev.solar_step = static_cast<int>(sym - SDLK_1) + 1;
             } else if (sym >= SDLK_F1 && sym <= SDLK_F9) {
                 int slot = static_cast<int>(sym - SDLK_F1) + 1;
                 if (mods & KMOD_SHIFT) ev.save_slot = slot;

--- a/src/runtime/host_window.cpp
+++ b/src/runtime/host_window.cpp
@@ -1555,6 +1555,11 @@ HostWindow::Events HostWindow::pump() {
                 // Solar-sensor debug level. The number row deliberately, since
                 // F1..F9 are already the save-state slots.
                 ev.solar_step = static_cast<int>(sym - SDLK_1) + 1;
+            } else if (sym == SDLK_0 &&
+                       !(mods & (KMOD_SHIFT | KMOD_CTRL | KMOD_ALT))) {
+                // 0 releases the override rather than meaning "level 0" —
+                // level 0 is already reachable as key 1 (brightness 0).
+                ev.solar_step = -1;
             } else if (sym >= SDLK_F1 && sym <= SDLK_F9) {
                 int slot = static_cast<int>(sym - SDLK_F1) + 1;
                 if (mods & KMOD_SHIFT) ev.save_slot = slot;

--- a/src/runtime/host_window.h
+++ b/src/runtime/host_window.h
@@ -113,6 +113,10 @@ public:
         int      load_slot = 0;
         // Debug light level for the Boktai solar sensor: number keys 1..9 pick
         // a brightness step (1 = darkest, 9 = full sun). 0 = unchanged.
+        // -1 (the 0 key) drops the manual override and hands the sensor back
+        // to the game's own light source, so a live provider — a camera, a
+        // weather service — can be spot-checked against a known level and
+        // then resumed within one session.
         int      solar_step = 0;
         // Level-triggered: true while the fast-forward (Turbo) binding is
         // held (default Tab). Uncaps the frame limiter for as long as it's

--- a/src/runtime/host_window.h
+++ b/src/runtime/host_window.h
@@ -111,13 +111,12 @@ public:
         // dispatch boundary), never mid-frame.
         int      save_slot = 0;
         int      load_slot = 0;
-        // Debug light level for the Boktai solar sensor: number keys 1..9 pick
-        // a brightness step (1 = darkest, 9 = full sun). 0 = unchanged.
-        // -1 (the 0 key) drops the manual override and hands the sensor back
-        // to the game's own light source, so a live provider — a camera, a
-        // weather service — can be spot-checked against a known level and
-        // then resumed within one session.
-        int      solar_step = 0;
+        // Optional, edge-triggered solar controls from config.ini [KeyMap].
+        // They have no built-in bindings; recomp-ui exposes them only for
+        // cartridges that declare a solar sensor.
+        bool     solar_brighter = false;
+        bool     solar_dimmer = false;
+        bool     solar_live = false;
         // Level-triggered: true while the fast-forward (Turbo) binding is
         // held (default Tab). Uncaps the frame limiter for as long as it's
         // down.

--- a/src/runtime/host_window.h
+++ b/src/runtime/host_window.h
@@ -111,6 +111,9 @@ public:
         // dispatch boundary), never mid-frame.
         int      save_slot = 0;
         int      load_slot = 0;
+        // Debug light level for the Boktai solar sensor: number keys 1..9 pick
+        // a brightness step (1 = darkest, 9 = full sun). 0 = unchanged.
+        int      solar_step = 0;
         // Level-triggered: true while the fast-forward (Turbo) binding is
         // held (default Tab). Uncaps the frame limiter for as long as it's
         // down.

--- a/src/runtime/launcher_seam.h
+++ b/src/runtime/launcher_seam.h
@@ -98,6 +98,65 @@ inline void set_has_gyro_controls(T& game_info, bool enabled) {
     }
 }
 
+// Same treatment for the solar-sensor fields, so this header still compiles
+// against a recomp-ui pin that predates them. Without the guard a game only has
+// to update gbarecomp to get a hard error in a third-party header it did not
+// change.
+template <typename T, typename = void>
+struct has_solar_sensor_field : std::false_type {};
+
+template <typename T>
+struct has_solar_sensor_field<
+    T, std::void_t<decltype(std::declval<T&>().has_solar_sensor)>>
+    : std::true_type {};
+
+template <typename T, typename = void>
+struct has_solar_settings : std::false_type {};
+
+template <typename T>
+struct has_solar_settings<
+    T, std::void_t<decltype(std::declval<T&>().solar_zip)>> : std::true_type {};
+
+template <typename T>
+inline void set_has_solar_sensor(T& game_info, bool enabled) {
+    if constexpr (has_solar_sensor_field<T>::value) {
+        game_info.has_solar_sensor = enabled ? 1 : 0;
+    }
+}
+
+// Returns false when this recomp-ui pin has no solar fields, so the caller can
+// leave config.ini [Solar] exactly as the game wrote it rather than round-trip
+// it through settings that do not exist.
+template <typename T, typename S>
+inline bool push_solar_settings(T& settings, const S& src) {
+    if constexpr (has_solar_settings<T>::value) {
+        std::snprintf(settings.solar_zip, sizeof(settings.solar_zip), "%s",
+                      src.zip.c_str());
+        std::snprintf(settings.solar_country, sizeof(settings.solar_country),
+                      "%s", src.country.c_str());
+        settings.solar_source      = src.source;
+        settings.solar_manual_step = src.manual_step;
+        settings.solar_full_sun    = src.full_sun;
+        return true;
+    }
+    return false;
+}
+
+template <typename T, typename S>
+inline bool pull_solar_settings(const T& settings, S* dst) {
+    if constexpr (has_solar_settings<T>::value) {
+        dst->zip         = settings.solar_zip;
+        dst->country     = settings.solar_country[0] ? settings.solar_country
+                                                     : "us";
+        dst->source      = settings.solar_source ? 1 : 0;
+        dst->manual_step = settings.solar_manual_step;
+        dst->full_sun    = settings.solar_full_sun > 0 ? settings.solar_full_sun
+                                                       : 900;
+        return true;
+    }
+    return false;
+}
+
 // gbarecomp's screen-model tokens, in the launcher's kGbaScreenKindNames
 // index order (Raw/Unlit/Frontlit/Backlit/Classic).
 inline const char* const kScreenTokens[5] = {
@@ -285,6 +344,103 @@ inline void seam_config_save(const std::string& path, const SeamConfig& c) {
     f << "gyro_sensitivity = " << c.gyro_sensitivity << "\n";
 }
 
+// ---- config.ini [Solar] ------------------------------------------------------
+// Cartridge light-sensor location, for games with RunOptions::has_solar_sensor.
+// The GAME also reads and writes this section (it owns the sensor's light
+// source), so the key names and the live/manual spelling here must match its
+// writer exactly, and unknown keys inside the section are preserved rather than
+// dropped -- the game keeps settings of its own here that the launcher has no
+// opinion about.
+struct SeamSolar {
+    std::string zip;
+    std::string country = "us";
+    int source = 0;        // 0 live, 1 manual
+    int manual_step = 0;   // 0..8
+    int full_sun = 900;    // W/m^2
+};
+
+inline void seam_solar_load(const std::string& path, SeamSolar* s) {
+    std::ifstream f(path);
+    if (!f) return;
+    std::string line;
+    bool in_section = false;
+    while (std::getline(f, line)) {
+        size_t b = line.find_first_not_of(" \t");
+        if (b == std::string::npos) continue;
+        size_t e = line.find_last_not_of(" \t\r\n");
+        std::string t = line.substr(b, e - b + 1);
+        if (t.empty() || t[0] == '#' || t[0] == ';') continue;
+        if (t[0] == '[') { in_section = t.rfind("[Solar]", 0) == 0; continue; }
+        if (!in_section) continue;
+        size_t eq = t.find('=');
+        if (eq == std::string::npos) continue;
+        auto trim = [](std::string v) {
+            size_t vb = v.find_first_not_of(" \t");
+            if (vb == std::string::npos) return std::string();
+            size_t ve = v.find_last_not_of(" \t");
+            return v.substr(vb, ve - vb + 1);
+        };
+        const std::string k = trim(t.substr(0, eq));
+        const std::string v = trim(t.substr(eq + 1));
+        if (k == "zip")              s->zip = v;
+        else if (k == "country")     s->country = v;
+        else if (k == "source")      s->source = (v == "manual") ? 1 : 0;
+        else if (k == "manual_step") s->manual_step = std::atoi(v.c_str());
+        else if (k == "full_sun")    s->full_sun = std::atoi(v.c_str());
+    }
+}
+
+inline void seam_solar_save(const std::string& path, const SeamSolar& s) {
+    std::vector<std::string> lines;
+    {
+        std::ifstream f(path);
+        std::string line;
+        while (std::getline(f, line)) {
+            while (!line.empty() && line.back() == '\r') line.pop_back();
+            lines.push_back(line);
+        }
+    }
+    // Keep every other section, and inside [Solar] keep the keys we do not own.
+    static const char* kOwned[] = {"zip", "country", "source", "manual_step",
+                                   "full_sun"};
+    std::vector<std::string> kept, foreign;
+    bool in_section = false;
+    for (const auto& l : lines) {
+        size_t b = l.find_first_not_of(" \t");
+        const bool is_header = b != std::string::npos && l[b] == '[';
+        if (is_header) in_section = l.compare(b, 7, "[Solar]") == 0;
+        if (is_header && in_section) continue;
+        if (in_section) {
+            if (b == std::string::npos) continue;
+            size_t eq = l.find('=');
+            if (eq != std::string::npos) {
+                std::string k = l.substr(b, eq - b);
+                while (!k.empty() && (k.back() == ' ' || k.back() == '\t'))
+                    k.pop_back();
+                bool owned = false;
+                for (const char* o : kOwned)
+                    if (k == o) { owned = true; break; }
+                if (!owned) foreign.push_back(l);
+            }
+            continue;   // drop comments and owned keys; they are rewritten
+        }
+        kept.push_back(l);
+    }
+    while (!kept.empty() && kept.back().empty()) kept.pop_back();
+
+    std::ofstream f(path, std::ios::trunc);
+    if (!f) return;
+    for (const auto& l : kept) f << l << "\n";
+    if (!kept.empty()) f << "\n";
+    f << "[Solar]\n";
+    f << "zip = " << s.zip << "\n";
+    f << "country = " << s.country << "\n";
+    f << "source = " << (s.source ? "manual" : "live") << "\n";
+    f << "manual_step = " << s.manual_step << "\n";
+    f << "full_sun = " << s.full_sun << "\n";
+    for (const auto& l : foreign) f << l << "\n";
+}
+
 // Append the persisted/committed settings as ordinary run_game() CLI args.
 inline void seam_append_setting_args(std::vector<std::string>& args,
                                      const SeamConfig& c,
@@ -407,6 +563,8 @@ inline int gbarecomp_launcher_preboot(std::vector<std::string>& args,
 
     SeamConfig cfg;
     seam_config_load(config_path, &cfg);
+    SeamSolar solar;
+    if (opts.has_solar_sensor) seam_solar_load(config_path, &solar);
     if (cfg.skip_launcher && !force_launcher) {
         // Boot straight in, but still honor the persisted settings.
         seam_append_setting_args(args, cfg, opts);
@@ -461,6 +619,8 @@ inline int gbarecomp_launcher_preboot(std::vector<std::string>& args,
     ls.volume        = cfg.volume;
     ls.player_src[0] = 1;                 // keyboard (gbarecomp host input)
     ls.skip_launcher = cfg.skip_launcher;
+    bool solar_in_launcher = false;
+    if (opts.has_solar_sensor) solar_in_launcher = push_solar_settings(ls, solar);
     ls.screen_kind   = cfg.screen_kind;
     ls.aspect_index  = cfg.aspect_index;
     gbarecomp_seam::set_gyro_sensitivity(ls, cfg.gyro_sensitivity);
@@ -483,6 +643,7 @@ inline int gbarecomp_launcher_preboot(std::vector<std::string>& args,
     }
     gi.widescreen_supported = opts.launcher_expose_widescreen &&
         opts.widescreen_view_width > 240 ? 1 : 0;
+    set_has_solar_sensor(gi, opts.has_solar_sensor);
     gi.adaptive_view_supported = opts.launcher_expose_adaptive_view &&
         opts.resize_driven_view && opts.max_resize_view_width > 240 ? 1 : 0;
     gi.config_path = config_path.c_str();
@@ -545,6 +706,11 @@ inline int gbarecomp_launcher_preboot(std::vector<std::string>& args,
                        ls, cfg.gyro_sensitivity),
                    0.25f, 4.00f);
     seam_config_save(config_path, cfg);
+    // Only rewrite [Solar] when this recomp-ui pin actually surfaced the panel;
+    // otherwise the values never round-tripped through it and writing them back
+    // would just churn the file the game owns.
+    if (solar_in_launcher && pull_solar_settings(ls, &solar))
+        seam_solar_save(config_path, solar);
 
     if (picked_rom[0]) {
         args.push_back("--rom");

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -100,16 +100,20 @@ namespace {
 // comparator threshold so the polarity lives in exactly one place.
 //
 // Two sources, in precedence order:
-//   1. the number-row debug keys, while an override is set;
+//   1. the optional solar hotkeys, while a manual override is set;
 //   2. RunOptions::solar_provider, the game's own light source.
 // With neither, the sensor reads dark — the behaviour before this seam.
-constexpr unsigned kSolarNoOverride = ~0u;
-std::atomic<unsigned> g_solar_override{kSolarNoOverride};
+constexpr int kSolarNoOverride = -1;
+constexpr unsigned kSolarSteps[9] = {
+    0, 8, 16, 24, 31, 63, 95, 127, 159,
+};
+std::atomic<int> g_solar_override_step{kSolarNoOverride};
 std::uint8_t (*g_solar_game_provider)() = nullptr;
 
 uint8_t solar_host_brightness() {
-    const unsigned ov = g_solar_override.load(std::memory_order_relaxed);
-    if (ov != kSolarNoOverride) return static_cast<uint8_t>(ov);
+    const int step = g_solar_override_step.load(std::memory_order_relaxed);
+    if (step != kSolarNoOverride)
+        return static_cast<uint8_t>(kSolarSteps[step]);
     if (g_solar_game_provider) return g_solar_game_provider();
     return 0;
 }
@@ -1379,7 +1383,7 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
         }
     }
     // Boktai's solar sensor: opt-in per game (no ROM signature exists for it).
-    // Light arrives either from the number-row debug keys or from the game's
+    // Light arrives either from optional, unbound hotkeys or from the game's
     // own RunOptions::solar_provider; the engine itself does no light I/O.
     {
         const char* se = std::getenv("GBARECOMP_SOLAR");
@@ -1387,6 +1391,8 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
                               (se && se[0] && se[0] != '0'));
     }
     bus.set_rom(rom.data(), rom.size());
+    g_solar_override_step.store(kSolarNoOverride, std::memory_order_relaxed);
+    g_solar_game_provider = nullptr;
     if (bus.solar().active()) {
         g_solar_game_provider = opts.solar_provider;
         bus.solar().set_provider(&solar_host_brightness);
@@ -2427,30 +2433,33 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
             input_record_last_value = ev.keyinput;
         }
         if (ev.quit) host_quit = true;
-        if (ev.solar_step < 0) {
+        if (bus.solar().active() && ev.solar_live) {
             // Release the manual override; the game's light source resumes.
-            g_solar_override.store(kSolarNoOverride, std::memory_order_relaxed);
+            g_solar_override_step.store(kSolarNoOverride,
+                                        std::memory_order_relaxed);
             std::printf("solar_override=off (%s)\n",
                         g_solar_game_provider ? "game provider resumes"
                                               : "no provider, sensor dark");
             std::fflush(stdout);
-        } else if (ev.solar_step) {
+        } else if (bus.solar().active() &&
+                   ev.solar_brighter != ev.solar_dimmer) {
             // Step -> brightness, shaped from measured in-game gauge response
             // rather than spread evenly over 0..255. An even spread wastes half
-            // the keys: Boktai's gauge saturates at brightness ~159, so 6/7/8/9
-            // all read as full sun. It is also very steep at the bottom — 0
-            // gives an empty gauge but 31 already gives 4 of 8 bars — so the low
-            // end gets finer steps.
+            // the range: Boktai's gauge saturates at brightness ~159. It is also
+            // very steep at the bottom — 0 gives an empty gauge but 31 already
+            // gives 4 of 8 bars — so the low end gets finer steps.
             //
             // Observed (linear map, 8 gauge bars): 0->0, 31->4, 63->5, 95->6,
             // 127->7, 159->full, and 191/223/255 indistinguishable from 159.
-            static constexpr unsigned kSolarSteps[9] = {
-                0, 8, 16, 24, 31, 63, 95, 127, 159,
-            };
-            const unsigned level = kSolarSteps[ev.solar_step - 1];
-            g_solar_override.store(level, std::memory_order_relaxed);
-            std::printf("solar_level=%d/9 brightness=%u (override; 0 releases)\n",
-                        ev.solar_step, level);
+            int step = g_solar_override_step.load(std::memory_order_relaxed);
+            if (ev.solar_brighter)
+                step = step == kSolarNoOverride ? 0 : std::min(step + 1, 8);
+            else
+                step = step == kSolarNoOverride ? 8 : std::max(step - 1, 0);
+            g_solar_override_step.store(step, std::memory_order_relaxed);
+            std::printf("solar_level=%d/9 brightness=%u (override; "
+                        "SolarLive releases)\n",
+                        step + 1, kSolarSteps[step]);
             std::fflush(stdout);
         }
         if (pacer) pacer->set_uncapped(ev.fast_forward);

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -57,6 +57,7 @@
 #include <condition_variable>
 #include <functional>
 #include <cstdint>
+#include <atomic>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -92,6 +93,16 @@ void runtime_set_frame_present_hook(std::function<bool()>);
 #ifndef GBARECOMP_DEFAULT_DEBUG_PORT
 #define GBARECOMP_DEFAULT_DEBUG_PORT 0
 #endif
+
+namespace {
+// Debug light level for the solar sensor, set by the number-row keys and read
+// once per conversion. 0 = darkest, 255 = full sun; gba_solar.h owns the
+// inversion to the comparator threshold so the polarity lives in one place.
+std::atomic<unsigned> g_solar_brightness{0};
+uint8_t solar_debug_brightness() {
+    return static_cast<uint8_t>(g_solar_brightness.load(std::memory_order_relaxed));
+}
+}  // namespace
 
 namespace gbarecomp {
 namespace {
@@ -1356,7 +1367,15 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
                 static_cast<unsigned>(ppu.view_extra_right()));
         }
     }
+    // Boktai's solar sensor: opt-in per game (no ROM signature exists for it).
+    // The debug provider is driven by the number-row keys; a camera backend
+    // replaces it later behind the same seam.
+    {
+        const char* se = std::getenv("GBARECOMP_SOLAR");
+        bus.set_solar_enabled(se && se[0] && se[0] != '0');
+    }
     bus.set_rom(rom.data(), rom.size());
+    if (bus.solar().active()) bus.solar().set_provider(&solar_debug_brightness);
 
     // Resolve the save chip once, with explicit and testable precedence:
     // ROM signature -> game config -> process environment. Keep type and
@@ -2393,6 +2412,24 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
             input_record_last_value = ev.keyinput;
         }
         if (ev.quit) host_quit = true;
+        if (ev.solar_step) {
+            // Step -> brightness, shaped from measured in-game gauge response
+            // rather than spread evenly over 0..255. An even spread wastes half
+            // the keys: Boktai's gauge saturates at brightness ~159, so 6/7/8/9
+            // all read as full sun. It is also very steep at the bottom — 0
+            // gives an empty gauge but 31 already gives 4 of 8 bars — so the low
+            // end gets finer steps.
+            //
+            // Observed (linear map, 8 gauge bars): 0->0, 31->4, 63->5, 95->6,
+            // 127->7, 159->full, and 191/223/255 indistinguishable from 159.
+            static constexpr unsigned kSolarSteps[9] = {
+                0, 8, 16, 24, 31, 63, 95, 127, 159,
+            };
+            const unsigned level = kSolarSteps[ev.solar_step - 1];
+            g_solar_brightness.store(level, std::memory_order_relaxed);
+            std::printf("solar_level=%d/9 brightness=%u\n", ev.solar_step, level);
+            std::fflush(stdout);
+        }
         if (pacer) pacer->set_uncapped(ev.fast_forward);
         // System hotkeys (config.ini [KeyMap], rebindable in the launcher).
         if (ev.toggle_fullscreen) {

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -95,12 +95,23 @@ void runtime_set_frame_present_hook(std::function<bool()>);
 #endif
 
 namespace {
-// Debug light level for the solar sensor, set by the number-row keys and read
-// once per conversion. 0 = darkest, 255 = full sun; gba_solar.h owns the
-// inversion to the comparator threshold so the polarity lives in one place.
-std::atomic<unsigned> g_solar_brightness{0};
-uint8_t solar_debug_brightness() {
-    return static_cast<uint8_t>(g_solar_brightness.load(std::memory_order_relaxed));
+// Host light level for the solar sensor, read once per ADC conversion.
+// 0 = darkest, 255 = full sun; gba_solar.h owns the inversion to the
+// comparator threshold so the polarity lives in exactly one place.
+//
+// Two sources, in precedence order:
+//   1. the number-row debug keys, while an override is set;
+//   2. RunOptions::solar_provider, the game's own light source.
+// With neither, the sensor reads dark — the behaviour before this seam.
+constexpr unsigned kSolarNoOverride = ~0u;
+std::atomic<unsigned> g_solar_override{kSolarNoOverride};
+std::uint8_t (*g_solar_game_provider)() = nullptr;
+
+uint8_t solar_host_brightness() {
+    const unsigned ov = g_solar_override.load(std::memory_order_relaxed);
+    if (ov != kSolarNoOverride) return static_cast<uint8_t>(ov);
+    if (g_solar_game_provider) return g_solar_game_provider();
+    return 0;
 }
 }  // namespace
 
@@ -1368,14 +1379,18 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
         }
     }
     // Boktai's solar sensor: opt-in per game (no ROM signature exists for it).
-    // The debug provider is driven by the number-row keys; a camera backend
-    // replaces it later behind the same seam.
+    // Light arrives either from the number-row debug keys or from the game's
+    // own RunOptions::solar_provider; the engine itself does no light I/O.
     {
         const char* se = std::getenv("GBARECOMP_SOLAR");
-        bus.set_solar_enabled(se && se[0] && se[0] != '0');
+        bus.set_solar_enabled(opts.has_solar_sensor ||
+                              (se && se[0] && se[0] != '0'));
     }
     bus.set_rom(rom.data(), rom.size());
-    if (bus.solar().active()) bus.solar().set_provider(&solar_debug_brightness);
+    if (bus.solar().active()) {
+        g_solar_game_provider = opts.solar_provider;
+        bus.solar().set_provider(&solar_host_brightness);
+    }
 
     // Resolve the save chip once, with explicit and testable precedence:
     // ROM signature -> game config -> process environment. Keep type and
@@ -2412,7 +2427,14 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
             input_record_last_value = ev.keyinput;
         }
         if (ev.quit) host_quit = true;
-        if (ev.solar_step) {
+        if (ev.solar_step < 0) {
+            // Release the manual override; the game's light source resumes.
+            g_solar_override.store(kSolarNoOverride, std::memory_order_relaxed);
+            std::printf("solar_override=off (%s)\n",
+                        g_solar_game_provider ? "game provider resumes"
+                                              : "no provider, sensor dark");
+            std::fflush(stdout);
+        } else if (ev.solar_step) {
             // Step -> brightness, shaped from measured in-game gauge response
             // rather than spread evenly over 0..255. An even spread wastes half
             // the keys: Boktai's gauge saturates at brightness ~159, so 6/7/8/9
@@ -2426,8 +2448,9 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
                 0, 8, 16, 24, 31, 63, 95, 127, 159,
             };
             const unsigned level = kSolarSteps[ev.solar_step - 1];
-            g_solar_brightness.store(level, std::memory_order_relaxed);
-            std::printf("solar_level=%d/9 brightness=%u\n", ev.solar_step, level);
+            g_solar_override.store(level, std::memory_order_relaxed);
+            std::printf("solar_level=%d/9 brightness=%u (override; 0 releases)\n",
+                        ev.solar_step, level);
             std::fflush(stdout);
         }
         if (pacer) pacer->set_uncapped(ev.fast_forward);

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -55,6 +55,26 @@ struct RunOptions {
     void (*extended_view_init)(std::uint32_t extra_left,
                                std::uint32_t extra_right) = nullptr;
 
+    // This cartridge carries a solar sensor. Unlike the RTC there is no ROM
+    // signature to detect one from, so it has to be declared. Games that leave
+    // this false are unaffected; GBARECOMP_SOLAR still forces it on for
+    // experiments, and RECOMP_SOLAR_OFF forces it off regardless.
+    bool has_solar_sensor = false;
+
+    // Optional game-owned light source for the cartridge solar sensor
+    // (gba_solar.h). Emulating the sensor is a runner CAPABILITY; deciding
+    // where light comes from is game POLICY, so anything with I/O — a camera,
+    // a weather service — belongs in the game binary behind this seam and not
+    // in the engine. Returns host brightness, 0 = dark, 255 = full sun.
+    //
+    // Sampled once per ADC conversion on the guest's thread, so it MUST be
+    // non-blocking: a network-backed provider polls on its own thread and
+    // answers from cache. Null leaves the sensor dark until a debug key is
+    // pressed, which is the pre-existing behaviour.
+    //
+    // The number-row debug keys override this while set; 0 releases them.
+    std::uint8_t (*solar_provider)() = nullptr;
+
     // ---- pre-boot launcher identity (launcher_seam.h, RECOMP_LAUNCHER builds) --
     // Consumed by the recomp-ui launcher seam a game's main() runs BEFORE
     // run_game(); the runtime itself never reads these. All optional.

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -69,10 +69,11 @@ struct RunOptions {
     //
     // Sampled once per ADC conversion on the guest's thread, so it MUST be
     // non-blocking: a network-backed provider polls on its own thread and
-    // answers from cache. Null leaves the sensor dark until a debug key is
-    // pressed, which is the pre-existing behaviour.
+    // answers from cache. Null leaves the sensor dark until a configured solar
+    // hotkey is pressed, which is the pre-existing behaviour.
     //
-    // The number-row debug keys override this while set; 0 releases them.
+    // SolarBrighter/SolarDimmer override this while set; SolarLive releases
+    // the override. All three are unbound by default.
     std::uint8_t (*solar_provider)() = nullptr;
 
     // ---- pre-boot launcher identity (launcher_seam.h, RECOMP_LAUNCHER builds) --


### PR DESCRIPTION
Three related pieces from bringing up a Boktai 1 (USA) target. Grouped because the sensor is what motivated the tooling, but they touch **disjoint files** — happy to split into three if you'd rather review them separately.

Independent of PR #5 (that one touches `oracle/CMakeLists.txt` and `setup-mgba.sh`; this touches `oracle/*.py`), so no conflict either way.

---

## 1. `GbaSolarSensor` — the first device on the GpioPort seam

Boktai's cart carries a photodiode behind an integrating ADC on the **same four GPIO pins as the S-3511A clock**, arbitrating on pin 2 (the RTC's chip select) so exactly one device is live at a time. That's precisely what `GpioPort`'s "every device sees every write and self-selects" model exists for — this is #3 carrying a second device.

Pin map and protocol, read from mGBA's `src/gba/cart/gpio.c` (`_lightReadPins`) as a **hardware reference only — no code derived from it** (mGBA is MPL-2.0; `third_party/README.md` requires the native build to carry no copyleft emulator deps, and `ARCHITECTURE.md` permits borrowing hardware behaviour from emulators and docs):

| pin | role |
|---|---|
| 0 | ADC clock — 12-bit counter advances on the rising edge |
| 1 | reset — zeroes the counter, latches one light sample |
| 2 | chip select — sensor inert while high (the RTC owns the bus) |
| 3 | comparator — driven high once `counter >= threshold` |

It reports light as a **time, not a value**: the guest resets, pulses the clock, and counts pulses until pin 3 flips. Fewer pulses = more light.

**The polarity is inverted and easy to get backwards**, so it goes through one named conversion (`brightness_to_threshold`). The latched sample is a *threshold*, so a small threshold trips sooner: `0x00` is brightest, `0xFF` darkest, and an absent sensor sits at `0xFF` and never trips. Getting this wrong makes sunlight read as midnight.

**Opt-in per game**, since unlike `SIIRTC_V` there's no ROM signature for the sensor:

- `bus.set_solar_enabled()` before `set_rom`
- `GBARECOMP_SOLAR` to arm, `RECOMP_SOLAR_OFF` to force off
- `RECOMP_SOLAR_FIXED=<0-255>` pins a constant for deterministic runs — same shape as `RECOMP_RTC_EPOCH`

Default off, so nothing changes for existing games. Host light arrives via a `LightProvider` function pointer, keeping the device layer free of I/O; a camera backend replaces the debug provider behind the same seam later.

### Verified against the real game, not just built

With the RTC pinned so it can't confound, the same driven path at `RECOMP_SOLAR_FIXED=0` vs `255` changes **10 bytes of guest IWRAM** — including the raw reading landing at `0x03004508` as `0xFF` (dark) vs `0x00` (full sun), exactly the inversion above. In a play session the in-game sun gauge ramps monotonically with the debug keys.

---

## 2. `oracle/diff_cart.py` — cart-aware first-divergence

`find_first_diverge.py` compares **BIOS** execution only: it drives `bios_smoke` and never passes `--rom`, so it can't say anything about a game. This is its cartridge sibling.

Both sides boot the same ROM, advance to the same **VBlank count** (hardware event, per the SYNC RULES — never a raw frame index), then PAL/OAM/VRAM/IWRAM are compared byte-for-byte. `--scan LO HI STEP` reports the **first** diverging point rather than an arbitrary one.

It exists to separate two failures that look identical on screen:

```
regions match, pixels differ  -> the COMPOSITOR is wrong
regions differ                -> guest EXECUTION diverged first
```

On a mismatch it also dumps DISPCNT/BGxCNT/WININ/WINOUT/BLDCNT/BLDALPHA/BLDY, since those usually explain a pixel difference when the regions agree.

Its docstring warns about RTC carts: the two processes read the clock independently, so an unpinned comparison can report a "divergence" that is only wall-time skew. I got caught by exactly that.

---

## 3. `oracle/*.py` — `.exe` portability

**26 scripts hardcoded a `.exe` suffix** on `bios_smoke` / `gbarecomp_oracle` / the game binary, so none could locate those executables on macOS or Linux where CMake emits no suffix. The oracle *binary* building off-Windows doesn't help if the harness around it can't find it.

Adds `recomp_paths.exe_name(stem)` and routes the names through it. Mechanical; **scripts keep their original CRLF line endings** so the diff stays reviewable rather than showing every file as fully rewritten.

One deliberate omission: `gba_cosim.py` still has `r"build-cosim\MinishCapRecomp.exe"`, whose *separator* — not just its suffix — is Windows-specific. Left alone rather than half-converted.

---

## Verification

- **16/16 engine test suites pass.**
- **41/41 oracle scripts byte-compile, 40/41 import cleanly** (`diff_audio_drift.py` needs numpy — pre-existing, unrelated).
- Sensor defaults off, so a build without `GBARECOMP_SOLAR` is unchanged.

Honest limit on part 3: the conversion is mechanical and I could only *execute* the scripts I actually use (the cart differ and the screenshot helper). The rest are verified compile-and-import only, since most need a Windows path or a MinishCap build I don't have.

## Known rough edge, flagged rather than hidden

The debug key table in `runtime.cpp` encodes Boktai's **measured** gauge response — it saturates near brightness 159 and is very steep below 31, so an even 0–255 spread wastes half the keys. By `ENHANCEMENTS.md` Rule 2 that curve is **game policy, not runner capability**, and belongs in `game.toml` as a `[solar].curve`. Happy to move it before merge if you'd prefer.
