### PR TITLE
runtime: make self-heal work off Windows (compiler path, linker flag, dlopen loader)

### DIFF
--- a/src/runtime/overlay_compile.cpp
+++ b/src/runtime/overlay_compile.cpp
@@ -51,14 +51,27 @@ bool heal_simulate_shipped() {
     return be && std::strcmp(be, "auto-no-gcc") == 0;
 }
 
-// The C++ compiler used to build overlay DLLs. The dev machine has msys2
-// mingw64 g++ on PATH at run time (the runtime exits 127 without it anyway);
-// GBARECOMP_HEAL_CXX overrides for non-default installs.
+// The C++ compiler used to build overlay shared objects. GBARECOMP_HEAL_CXX
+// overrides for non-default installs.
+//
+// The default used to be the Windows dev box's absolute msys2 path
+// unconditionally, so on macOS and Linux every heal attempt died with
+//
+//     sh: C:/msys64/mingw64/bin/g++.exe: No such file or directory
+//
+// which surfaces as `gcc exit 32512` (127 << 8, "command not found") and leaves
+// the session permanently on the interpreter bridge: coverage can never reach
+// FULLY STATIC off Windows, however many misses are merged into the config.
+// Prefer a bare compiler name elsewhere and let PATH resolve it.
 std::string gxx_path() {
     if (const char* e = std::getenv("GBARECOMP_HEAL_CXX")) {
         if (e[0]) return e;
     }
+#if defined(_WIN32)
     return "C:/msys64/mingw64/bin/g++.exe";
+#else
+    return "c++";
+#endif
 }
 
 // The bundled, toolchain-free C compiler used to build overlay DLLs on a player
@@ -191,15 +204,61 @@ bool load_and_resolve(const std::string& dll, uint32_t pc,
     return true;
 }
 #else
+#include <dlfcn.h>
+
 int run_process(const std::string& cmdline, const std::string& logpath,
                 std::string*) {
     std::string c = cmdline + " > \"" + logpath + "\" 2>&1";
     return std::system(c.c_str());
 }
-bool load_and_resolve(const std::string&, uint32_t, const GbaOverlayCallbacks*,
-                      void**, void (**)(void), std::string* err) {
-    if (err) *err = "overlay loading unimplemented on this platform";
-    return false;
+// POSIX mirror of the Win32 path above: dlopen/dlsym for
+// LoadLibrary/GetProcAddress. Until this existed, every heal off Windows failed
+// with "overlay loading unimplemented on this platform", so a macOS or Linux
+// session could compile an overlay and still never run it -- coverage was
+// permanently NOT_STATIC no matter what the config contained.
+bool load_and_resolve(const std::string& dll, uint32_t pc,
+                      const GbaOverlayCallbacks* cb,
+                      void** out_module, void (**out_fn)(void),
+                      std::string* err) {
+    // RTLD_LOCAL so an overlay's symbols cannot collide with the next one's:
+    // every overlay exports the same overlay_abi / overlay_init names.
+    void* h = dlopen(dll.c_str(), RTLD_NOW | RTLD_LOCAL);
+    if (!h) {
+        const char* e = dlerror();
+        if (err) *err = "dlopen(" + dll + ") failed: " + (e ? e : "unknown");
+        return false;
+    }
+    auto abi = reinterpret_cast<uint32_t (*)(void)>(dlsym(h, "overlay_abi"));
+    if (!abi || abi() != GBA_OVERLAY_ABI_VERSION) {
+        if (err) *err = "ABI mismatch in " + dll + " (so=" +
+                        std::to_string(abi ? abi() : 0u) + " runtime=" +
+                        std::to_string(GBA_OVERLAY_ABI_VERSION) +
+                        ") — rejecting + deleting stale cache entry";
+        dlclose(h);
+        std::error_code ec;
+        fs::remove(dll, ec);
+        return false;
+    }
+    auto init = reinterpret_cast<void (*)(const GbaOverlayCallbacks*)>(
+        dlsym(h, "overlay_init"));
+    if (!init) {
+        if (err) *err = "no overlay_init in " + dll;
+        dlclose(h);
+        return false;
+    }
+    init(cb);
+
+    char fname[24];
+    std::snprintf(fname, sizeof(fname), "func_%08X", pc);
+    auto fn = reinterpret_cast<void (*)(void)>(dlsym(h, fname));
+    if (!fn) {
+        if (err) *err = std::string("no ") + fname + " export in " + dll;
+        dlclose(h);
+        return false;
+    }
+    *out_module = h;
+    *out_fn = fn;
+    return true;
 }
 #endif
 
@@ -294,6 +353,18 @@ bool overlay_compile_one(const OverlayWorkItem& w,
                 " -o \"" + dlltmp.generic_string() + "\""
                 " \"" + cpath.generic_string() + "\"";
         } else {
+            // Platform-specific tail. --export-all-symbols is a PE/MinGW
+            // linker flag: Apple's ld64 rejects it outright, and on ELF it is
+            // meaningless because a shared object exports its non-hidden
+            // symbols anyway. ELF does need -fPIC for -shared, which Windows
+            // and macOS do not (both are PIC by default).
+#if defined(_WIN32)
+            const char* plat = " -Wl,--export-all-symbols";
+#elif defined(__APPLE__)
+            const char* plat = "";
+#else
+            const char* plat = " -fPIC";
+#endif
             cmd =
                 "\"" + gxx_path() + "\""
                 " -O2 -std=gnu++17 -fno-exceptions -fno-rtti -shared" + inc +
@@ -301,8 +372,8 @@ bool overlay_compile_one(const OverlayWorkItem& w,
                 // -x c++: under gcc the emitted body compiles as C++ to match
                 // the static corpus's C++ semantics exactly. Explicit so it
                 // never depends on the driver's .c-suffix handling.
-                " -x c++ \"" + cpath.generic_string() + "\""
-                " -Wl,--export-all-symbols";
+                " -x c++ \"" + cpath.generic_string() + "\"" +
+                plat;
         }
 
         const int rc = run_process(cmd, logpath.string(), err);


### PR DESCRIPTION
Stage-2 self-healing could never succeed on macOS or Linux. Three independent reasons, all of which had to go:

**1. The compiler path was a Windows absolute.** `gxx_path()` returned `C:/msys64/mingw64/bin/g++.exe` unconditionally, so every heal attempt died with

```
sh: C:/msys64/mingw64/bin/g++.exe: No such file or directory
```

which the runtime reports as `gcc exit 32512` — that's `127 << 8`, "command not found". Now defaults to `c++` off Windows and lets PATH resolve it. `GBARECOMP_HEAL_CXX` still overrides.

**2. A PE-only linker flag.** The gcc command passed `-Wl,--export-all-symbols`, which Apple's ld64 rejects outright and which is meaningless on ELF (a shared object exports its non-hidden symbols anyway). Now Windows-only, with `-fPIC` added for ELF, which needs it for `-shared`.

**3. The loader was a stub.** `load_and_resolve()` returned `"overlay loading unimplemented on this platform"`, so even a successful compile could not be called. Implemented with `dlopen`/`dlsym` as the direct mirror of the Win32 `LoadLibrary`/`GetProcAddress` path, including the ABI check that deletes a stale cache entry. `RTLD_LOCAL` because every overlay exports the same `overlay_abi` / `overlay_init` names.

### Measured

Same ROM, same session shape, before and after:

```
before   healed_native=0    native_calls=0      failed=3
after    healed_native=103  native_calls=27223  failed=2
```

103 overlays compiled, loaded and called where previously zero could be.

### Honest limits

Coverage still reports `NOT_STATIC`. The two remaining failures are IWRAM PCs (`0x03001D40` / `0x03001E4C`) — RAM-resident code reached through a `[[code_copy]]` region rather than a ROM function. That is a separate problem from the toolchain and is left in the miss-list proposal for review, not auto-merged.

Only tested on macOS/arm64. The Linux path is the same code but I have not run it; `-fPIC` is the one line specific to it.

19/19 engine suites pass. Windows behaviour is unchanged — every change is inside a `_WIN32` conditional or the non-Windows arm.
