### PR TITLE
bios: don't name the reset vector `_start` — it collides with glibc and breaks every Linux build

### DIFF
--- a/bios/gba_bios.toml
+++ b/bios/gba_bios.toml
@@ -23,12 +23,22 @@ md5  = "a860e8c0b6d573d191e4ec7db1b1e4f6"
 # only deliberately-named labels survive. Plus a hand-coded
 # tail of exception-vector slots (0x08 SWI, 0x18 IRQ) that the
 # runtime dispatches separately even though the disasm groups
-# them under a single `_start` label.
+# them under a single reset label.
+#
+# The reset vector is deliberately NOT named `_start`: the recompiler emits each
+# entry as a C function of the same name, and on Linux/glibc `_start` is the
+# process entry point in Scrt1.o, so every game fails to link with
+#
+#   multiple definition of `_start';
+#   .../Scrt1.o:.../start.S:57: first defined here
+#
+# Windows and macOS use different CRT entry symbols and never hit it. The bios_
+# prefix also matches the vector entries below.
 
 [[extra_func]]
 addr = 0x00000000
 mode = "arm"
-name = "_start"
+name = "bios_reset_vector"
 
 [[extra_func]]
 addr = 0x00000008

--- a/src/runtime/generated_bios/bios_dispatch_table.cpp
+++ b/src/runtime/generated_bios/bios_dispatch_table.cpp
@@ -9,7 +9,7 @@
 
 struct DispatchEntry { uint32_t addr; uint8_t thumb; uint8_t resume; void (*fn)(void); };
 extern "C" const DispatchEntry kBiosDispatchTable[] = {
-    {0x00000000u, 0u, 0u, _start},
+    {0x00000000u, 0u, 0u, bios_reset_vector},
     {0x00000008u, 0u, 0u, bios_swi_vector},
     {0x00000018u, 0u, 0u, bios_irq_vector},
     {0x0000001Cu, 0u, 0u, reserved_vector},


### PR DESCRIPTION
`bios/gba_bios.toml` names the reset vector at `0x00000000` literally `_start`. The recompiler emits every configured entry as a C function of the same name, so the generated BIOS contains `void _start(void)` — and on Linux/glibc `_start` is the process entry point, provided by `Scrt1.o`. Linking any game fails:

```
ld: libgbarecomp_runtime.a(bios_recompiled.cpp.o): in function `_start':
    bios_recompiled.cpp:17: multiple definition of `_start';
    /usr/lib/.../Scrt1.o:.../start.S:57: first defined here
collect2: error: ld returned 1 exit status
```

Windows and macOS use different CRT entry symbols (`mainCRTStartup`, `start`) and never collide, which is why this has gone unnoticed. It reproduces on **any** Linux host and blocks Linux and Steam Deck builds of every game in the ecosystem, not just this one — I hit it building a Deck flatpak, where it was the last thing between a clean compile and a linked binary.

## The change

Renamed to `bios_reset_vector` and regenerated. That name matches the prefix the neighbouring vector entries already use in the same file (`bios_swi_vector`, `bios_irq_vector`), so it is also more consistent than what it replaces.

The address, mode, and dispatch behaviour are untouched — this is purely the label the recompiler emits, and the symbol map entry that follows from it.

## Verification

- **19/19 engine suites pass** on macOS after regenerating, so the rename is behaviour-neutral on the platforms that already worked.
- The Deck now links the game and the resulting flatpak launches.

## Note on the regenerated output

`src/runtime/generated_bios/` is committed in this repo, so the diff includes the regenerated BIOS alongside the one-line TOML change. The only textual differences are the symbol name itself and its `bios_symbol_map.cpp` entry — happy to split the regeneration into its own commit if you would rather review them separately.
