### PR TITLE
Add reusable Assist, pacing, and presentation hooks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,6 +347,16 @@ if(EXISTS "${GBARECOMP_GENERATED_BIOS_DIR}/bios_recompiled.cpp")
         "${GBARECOMP_GENERATED_BIOS_DIR}/bios_recompiled.cpp")
     target_compile_definitions(gbarecomp_runtime PUBLIC
         GBARECOMP_HAVE_BIOS_RECOMP=1)
+    if(NOT WIN32)
+        # The recompiled BIOS reset vector is named `_start` after its crt0
+        # label. On ELF hosts that collides with the process entry symbol from
+        # Scrt1.o, so rename the guest symbol consistently across the
+        # generated BIOS translation units. PUBLIC keeps any dependent that
+        # includes bios_recompiled.h in agreement. Windows entry symbols
+        # differ, so the historical name is preserved there.
+        target_compile_definitions(gbarecomp_runtime PUBLIC
+            _start=gbarecomp_bios_reset_start)
+    endif()
     message(STATUS "gbarecomp: BIOS recompiled output present — linking")
 else()
     target_sources(gbarecomp_runtime PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,41 @@ endif()
 # armv4t — portable ARM7TDMI decoder, IR, codegen. Reusable for ARM9 later.
 # Must NOT depend on src/gba or src/runtime.
 # ─────────────────────────────────────────────────────────────────────────────
+# Parent game projects can opt into a double-clickable MinGW development
+# directory without duplicating the same four-DLL staging recipe. Static
+# release targets deliberately skip this because those dependencies are baked
+# into the executable.
+set(GBARECOMP_MINGW_RUNTIME_BIN "C:/msys64/mingw64/bin"
+    CACHE PATH "Directory containing MinGW runtime DLLs for development builds")
+
+function(gbarecomp_stage_mingw_runtime target_name)
+    if(NOT TARGET "${target_name}")
+        message(FATAL_ERROR
+            "gbarecomp_stage_mingw_runtime: unknown target '${target_name}'")
+    endif()
+    if(NOT WIN32 OR NOT MINGW OR GBARECOMP_STATIC_RELEASE)
+        return()
+    endif()
+
+    foreach(runtime_dll IN ITEMS
+            SDL2.dll
+            libgcc_s_seh-1.dll
+            libstdc++-6.dll
+            libwinpthread-1.dll)
+        set(runtime_source "${GBARECOMP_MINGW_RUNTIME_BIN}/${runtime_dll}")
+        if(EXISTS "${runtime_source}")
+            add_custom_command(TARGET "${target_name}" POST_BUILD
+                COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+                    "${runtime_source}"
+                    "$<TARGET_FILE_DIR:${target_name}>/${runtime_dll}"
+                VERBATIM)
+        else()
+            message(WARNING
+                "gbarecomp: development runtime DLL not found: ${runtime_source}")
+        endif()
+    endforeach()
+endfunction()
+
 add_library(gbarecomp_armv4t STATIC
     src/armv4t/arm_decode.cpp
     src/armv4t/thumb_decode.cpp
@@ -295,14 +330,21 @@ if(GBARECOMP_ENABLE_MODS)
         "Enable recomp-ui Mods view for this GBA mod-enabled game" FORCE)
 endif()
 
+# Keep private BIOS-derived output out of a framework checkout when a game
+# supplies a build-local directory. The source-tree default preserves the
+# existing standalone workflow.
+set(GBARECOMP_GENERATED_BIOS_DIR
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/runtime/generated_bios"
+    CACHE PATH "Directory containing locally generated BIOS recompilation sources")
+
 # When the user has run `gba_recompile --bios`, the recompiled BIOS
 # functions live in src/runtime/generated_bios/bios_recompiled.cpp.
 # We can't list it unconditionally because the placeholder build
 # doesn't have it. Pull it in if present.
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/runtime/generated_bios/bios_recompiled.cpp")
+if(EXISTS "${GBARECOMP_GENERATED_BIOS_DIR}/bios_recompiled.cpp")
     target_sources(gbarecomp_runtime PRIVATE
-        src/runtime/generated_bios/bios_dispatch_table.cpp
-        src/runtime/generated_bios/bios_recompiled.cpp)
+        "${GBARECOMP_GENERATED_BIOS_DIR}/bios_dispatch_table.cpp"
+        "${GBARECOMP_GENERATED_BIOS_DIR}/bios_recompiled.cpp")
     target_compile_definitions(gbarecomp_runtime PUBLIC
         GBARECOMP_HAVE_BIOS_RECOMP=1)
     message(STATUS "gbarecomp: BIOS recompiled output present — linking")

--- a/src/debug/snapshot.cpp
+++ b/src/debug/snapshot.cpp
@@ -105,7 +105,12 @@ void deserialize_meta(SnapshotReader& r, const SnapshotContext& ctx) {
 
 }  // namespace
 
-bool save_state(const char* path, const SnapshotContext& ctx, std::string* err) {
+bool save_state_bytes(std::vector<uint8_t>* out, const SnapshotContext& ctx,
+                      std::string* err) {
+    if (!out) {
+        if (err) *err = "snapshot: output buffer not provided";
+        return false;
+    }
     if (!ctx.bus || !ctx.ppu) {
         if (err) *err = "snapshot: bus/ppu not wired";
         return false;
@@ -141,13 +146,21 @@ bool save_state(const char* path, const SnapshotContext& ctx, std::string* err) 
         w.bytes(mods.buffer().data(), mods.size());
     }
 
+    *out = w.take_buffer();
+    return true;
+}
+
+bool save_state(const char* path, const SnapshotContext& ctx, std::string* err) {
+    std::vector<uint8_t> blob;
+    if (!save_state_bytes(&blob, ctx, err)) return false;
+
     std::ofstream f(path, std::ios::binary | std::ios::trunc);
     if (!f) {
         if (err) *err = std::string("snapshot: cannot open for write: ") + path;
         return false;
     }
-    f.write(reinterpret_cast<const char*>(w.buffer().data()),
-            static_cast<std::streamsize>(w.size()));
+    f.write(reinterpret_cast<const char*>(blob.data()),
+            static_cast<std::streamsize>(blob.size()));
     if (!f) {
         if (err) *err = std::string("snapshot: write failed: ") + path;
         return false;
@@ -155,32 +168,19 @@ bool save_state(const char* path, const SnapshotContext& ctx, std::string* err) 
     return true;
 }
 
-bool load_state(const char* path, const SnapshotContext& ctx, std::string* err) {
+bool load_state_bytes(const uint8_t* data, std::size_t size,
+                      const SnapshotContext& ctx, std::string* err) {
     if (!ctx.bus || !ctx.ppu) {
         if (err) *err = "snapshot: bus/ppu not wired";
         return false;
     }
 
-    std::ifstream f(path, std::ios::binary | std::ios::ate);
-    if (!f) {
-        if (err) *err = std::string("snapshot: cannot open for read: ") + path;
-        return false;
-    }
-    std::streamoff size = f.tellg();
-    if (size <= 0) {
-        if (err) *err = std::string("snapshot: empty/unreadable: ") + path;
-        return false;
-    }
-    std::vector<uint8_t> blob(static_cast<std::size_t>(size));
-    f.seekg(0, std::ios::beg);
-    f.read(reinterpret_cast<char*>(blob.data()),
-           static_cast<std::streamsize>(blob.size()));
-    if (!f) {
-        if (err) *err = std::string("snapshot: read failed: ") + path;
+    if (!data || size == 0) {
+        if (err) *err = "snapshot: empty/unreadable memory state";
         return false;
     }
 
-    SnapshotReader head(blob.data(), blob.size());
+    SnapshotReader head(data, size);
     char magic[4];
     head.bytes(magic, 4);
     if (std::memcmp(magic, kMagic, 4) != 0) {
@@ -223,9 +223,9 @@ bool load_state(const char* path, const SnapshotContext& ctx, std::string* err) 
     // Index sections by tag → (offset, len) within blob.
     struct Span { std::size_t off; std::size_t len; };
     std::unordered_map<uint32_t, Span> sections;
-    std::size_t cursor = blob.size() - head.remaining();
+    std::size_t cursor = size - head.remaining();
     for (uint32_t i = 0; i < section_count; ++i) {
-        SnapshotReader sr(blob.data() + cursor, blob.size() - cursor);
+        SnapshotReader sr(data + cursor, size - cursor);
         uint32_t tag = sr.u32();
         uint32_t len = sr.u32();
         if (!sr.ok()) {
@@ -233,7 +233,7 @@ bool load_state(const char* path, const SnapshotContext& ctx, std::string* err) 
             return false;
         }
         const std::size_t payload_off = cursor + 8;
-        if (len > blob.size() - payload_off) {
+        if (payload_off > size || len > size - payload_off) {
             if (err) *err = "snapshot: section overruns file";
             return false;
         }
@@ -246,7 +246,7 @@ bool load_state(const char* path, const SnapshotContext& ctx, std::string* err) 
     }
 
     const bool legacy_v1 = version == kLegacySnapshotVersion;
-    if (cursor != blob.size()) {
+    if (cursor != size) {
         if (err) *err = "snapshot: trailing container data";
         return false;
     }
@@ -294,7 +294,7 @@ bool load_state(const char* path, const SnapshotContext& ctx, std::string* err) 
         return false;
     }
     if (mods_it != sections.end()) {
-        SnapshotReader mods_reader(blob.data() + mods_it->second.off, mods_it->second.len);
+        SnapshotReader mods_reader(data + mods_it->second.off, mods_it->second.len);
         ModStateRegistry empty_catalog;
         const ModStateRegistry& catalog = ctx.mod_state ? *ctx.mod_state : empty_catalog;
         if (!catalog.preflight(mods_reader, err)) {
@@ -306,7 +306,7 @@ bool load_state(const char* path, const SnapshotContext& ctx, std::string* err) 
     auto reader_for = [&](uint32_t tag) -> SnapshotReader {
         auto it = sections.find(tag);
         const uint8_t* base = (it == sections.end())
-            ? nullptr : blob.data() + it->second.off;
+            ? nullptr : data + it->second.off;
         std::size_t len = (it == sections.end()) ? 0 : it->second.len;
         return SnapshotReader(base, len);
     };
@@ -322,7 +322,7 @@ bool load_state(const char* path, const SnapshotContext& ctx, std::string* err) 
         deserialize_meta(r, ctx);
     }
     if (mods_it != sections.end() && ctx.mod_state && ctx.mod_state->size() != 0) {
-        SnapshotReader mods_reader(blob.data() + mods_it->second.off, mods_it->second.len);
+        SnapshotReader mods_reader(data + mods_it->second.off, mods_it->second.len);
         // A matching payload was already preflighted above.  Restore is a
         // provider contract, not a recoverable error path: guest state is now
         // live, so continuing after a provider violation would be unsafe.
@@ -330,6 +330,28 @@ bool load_state(const char* path, const SnapshotContext& ctx, std::string* err) 
     }
 
     return true;
+}
+
+bool load_state(const char* path, const SnapshotContext& ctx, std::string* err) {
+    std::ifstream f(path, std::ios::binary | std::ios::ate);
+    if (!f) {
+        if (err) *err = std::string("snapshot: cannot open for read: ") + path;
+        return false;
+    }
+    const std::streamoff file_size = f.tellg();
+    if (file_size <= 0) {
+        if (err) *err = std::string("snapshot: empty/unreadable: ") + path;
+        return false;
+    }
+    std::vector<uint8_t> blob(static_cast<std::size_t>(file_size));
+    f.seekg(0, std::ios::beg);
+    f.read(reinterpret_cast<char*>(blob.data()),
+           static_cast<std::streamsize>(blob.size()));
+    if (!f) {
+        if (err) *err = std::string("snapshot: read failed: ") + path;
+        return false;
+    }
+    return load_state_bytes(blob.data(), blob.size(), ctx, err);
 }
 
 }  // namespace gbarecomp::debug

--- a/src/debug/snapshot.h
+++ b/src/debug/snapshot.h
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <cstring>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace gba {
@@ -56,6 +57,7 @@ public:
     }
 
     const std::vector<uint8_t>& buffer() const { return buf_; }
+    std::vector<uint8_t> take_buffer() { return std::move(buf_); }
     std::size_t size() const { return buf_.size(); }
 
 private:
@@ -132,8 +134,16 @@ struct SnapshotContext {
 // clean dispatch boundary. Returns false (with *err set) on I/O error.
 bool save_state(const char* path, const SnapshotContext& ctx, std::string* err);
 
+// In-memory variants used by bounded rewind histories. They use exactly the
+// same versioned, ROM-gated container as on-disk states, so there is only one
+// serializer to keep correct.
+bool save_state_bytes(std::vector<uint8_t>* out, const SnapshotContext& ctx,
+                      std::string* err);
+
 // Restore from `path`. Returns false (with *err set) on I/O error,
 // bad magic, version mismatch, ROM-hash mismatch, or truncation.
 bool load_state(const char* path, const SnapshotContext& ctx, std::string* err);
+bool load_state_bytes(const uint8_t* data, std::size_t size,
+                      const SnapshotContext& ctx, std::string* err);
 
 }  // namespace gbarecomp::debug

--- a/src/gba/gba_ppu.cpp
+++ b/src/gba/gba_ppu.cpp
@@ -38,6 +38,15 @@ extern "C" int (*g_ws_obj_x_provider)(int, int*) = nullptr;
 extern "C" int (*g_ws_obj_attr_x_provider)(int, std::uint16_t,
                                             std::uint16_t, std::uint16_t,
                                             int*) = nullptr;
+// Opt-in OBJ margin policy: clip OBJ pixels to the native 240px viewport in
+// expanded rendering. Games routinely park sprites just past the visible edge
+// (signed 9-bit OAM X, or Y-wrapped); without this clip those parked sprites
+// become visible inside widescreen margins. Default off preserves each
+// established per-game behavior. g_ws_obj_attr_x_provider/g_ws_obj_x_provider
+// still run first, so a game can re-place known-safe HUD sprites and clip the
+// rest.
+extern "C" int g_ws_obj_native_clip = 0;
+
 namespace {
 
 // These pointers have no C linkage and are deliberately not declared by the
@@ -1479,6 +1488,7 @@ void render_scanline_wide(uint8_t* rgb, uint32_t y, uint16_t dispcnt,
             // the provider below, so they cannot repeat.
             if (!layer_enabled(x, layer) && !authored_margin) continue;
             int sample_hx = hx;
+            bool remapped = false;
             if (g_ws_bg_x_provider &&
                 (g_ws_bg_x_provider_layers & (1u << layer))) {
                 int provided_hx = hx;
@@ -1486,8 +1496,19 @@ void render_scanline_wide(uint8_t* rgb, uint32_t y, uint16_t dispcnt,
                     static_cast<int>(layer), static_cast<int>(x),
                     static_cast<int>(y), &provided_hx);
                 if (action < 0) continue;
-                if (action > 0) sample_hx = provided_hx;
+                if (action > 0) { sample_hx = provided_hx; remapped = true; }
             }
+            // A remapped margin sample continues an authentic viewport
+            // column, so gate it by that column's own window control instead
+            // of the margin's WINOUT fallback. Otherwise reflected
+            // continuations vanish exactly when a guest window covers the
+            // scenery they mirror (e.g. battle arenas whose WINOUT drops the
+            // world layer behind HUD windows). Non-remapped margins keep the
+            // established WINOUT/fail-closed behavior.
+            if (remapped && (hx < 0 || hx >= static_cast<int>(kVanW)) &&
+                sample_hx >= 0 && sample_hx < static_cast<int>(kVanW) &&
+                (window_control_at_hx(sample_hx) & (1u << layer)) == 0)
+                continue;
             uint32_t tex_x = static_cast<uint32_t>(
                                  sample_hx + static_cast<int>(hofs)) &
                              (width_px - 1u);
@@ -1822,6 +1843,13 @@ void render_scanline_wide(uint8_t* rgb, uint32_t y, uint16_t dispcnt,
             bool obj_target2 = (second_targets & (1u << 4)) != 0;
             auto emit_obj = [&](int tex_x, int tex_y, int screen_x) {
                 if (screen_x < 0 || screen_x >= static_cast<int>(out_w)) return;
+                // Opt-in policy: hardware-faithful OBJ placement only within
+                // the native viewport; margin columns never show sprites the
+                // guest believed were off-screen.
+                if (g_ws_obj_native_clip &&
+                    (screen_x < static_cast<int>(ox) ||
+                     screen_x >= static_cast<int>(ox) + static_cast<int>(kVanW)))
+                    return;
                 if (!layer_enabled(static_cast<uint32_t>(screen_x), 4)) return;
                 int tile_x_in_sprite = tex_x >> 3;
                 int tile_y_in_sprite = tex_y >> 3;

--- a/src/gba/gba_ppu.h
+++ b/src/gba/gba_ppu.h
@@ -243,5 +243,11 @@ extern "C" int (*g_ws_obj_attr_x_provider)(int oam_index,
                                             std::uint16_t attr1,
                                             std::uint16_t attr2,
                                             int* out_x);
+// Opt-in policy for expanded rendering: when nonzero, OBJ pixels are clipped
+// to the native 240px viewport so sprites the guest parked just off-screen
+// (signed 9-bit X idiom) never appear inside widescreen margins. The OBJ x
+// providers above run first and may re-place known-safe sprites. Default 0
+// keeps the established expanded-viewport OBJ test.
+extern "C" int g_ws_obj_native_clip;
 
 }  // namespace gba

--- a/src/runtime/host_window.cpp
+++ b/src/runtime/host_window.cpp
@@ -1121,25 +1121,26 @@ bool HostWindow::open(int scale, int base_w, int base_h, const char* title,
 #if defined(__ANDROID__)
     b->fullscreen = 1;
 #endif
-    // The independent FramePacer still governs emulation at 59.7275 Hz
-    // (MC-HP-004) — vsync below only aligns scanout, in series after the
-    // pacer, and can never become the game clock.
-    // HP-002: EVERY path now requests a synchronized present. The cadence
-    // probe measured the legacy D3D9 blit returning in <1 ms despite
-    // vsync=yes (presents never sync to scanout → the tear band users see
-    // toward the bottom at native res). SDL2's D3D11 backend is a DXGI
-    // flip-model swapchain whose vsync genuinely blocks, and windowed VRR
-    // (G-Sync "windowed and full screen") can engage through it — so prefer
-    // it by default on Windows; SDL_RENDER_DRIVER in the environment still
-    // overrides. GBARECOMP_NO_VSYNC=1 restores the historical
-    // unsynchronized present for A/B.
+    // FramePacer is the sole emulation clock at the GBA's native 59.7275 Hz.
+    // Do not put a blocking monitor-VSync present in series with it by default:
+    // on a 165 Hz display that consumed a measured 4 ms median / 11 ms p95 of
+    // the frame budget, reducing a warm GBA workload to 47-49 FPS and forcing
+    // the audio bridge to stretch continuously. DWM still composites ordinary
+    // windowed presentation; users who prefer synchronized fullscreen output
+    // can opt in with GBARECOMP_VSYNC=1. GBARECOMP_NO_VSYNC remains the final
+    // override for existing launch scripts and A/B diagnostics.
 #if defined(_WIN32)
     SDL_SetHintWithPriority(SDL_HINT_RENDER_DRIVER, "direct3d11",
                             SDL_HINT_DEFAULT);
 #endif
+    const char* vsync_env = std::getenv("GBARECOMP_VSYNC");
     const char* no_vsync_env = std::getenv("GBARECOMP_NO_VSYNC");
+    const bool vsync_requested =
+        vsync_env && *vsync_env && *vsync_env != '0';
+    const bool vsync_disabled =
+        no_vsync_env && *no_vsync_env && *no_vsync_env != '0';
     const bool want_vsync =
-        !(no_vsync_env && *no_vsync_env && *no_vsync_env != '0');
+        vsync_requested && !vsync_disabled;
     const Uint32 renderer_flags = SDL_RENDERER_ACCELERATED |
         (want_vsync ? static_cast<Uint32>(SDL_RENDERER_PRESENTVSYNC)
                     : Uint32{0});

--- a/src/runtime/host_window.cpp
+++ b/src/runtime/host_window.cpp
@@ -375,6 +375,7 @@ struct Backend {
         assist_pad_axis(SDL_CONTROLLER_AXIS_TRIGGERRIGHT, true),
     };
     bool         assist_tools = true;
+    int          assist_fast_forward_multiplier = 4;
     bool         assist_rewind_was_down = false;
     Uint32       assist_rewind_repeat_at = 0;
     int          scale = 3;             // current integer window scale
@@ -1669,10 +1670,13 @@ void HostWindow::present(const uint8_t* rgb888) {
 }
 
 void HostWindow::load_input_config(const char* dir,
-                                   bool assist_tools_default) {
+                                   bool assist_tools_default,
+                                   int fast_forward_multiplier_default) {
     if (!open_ || !impl_ || !dir) return;
     auto* b = static_cast<Backend*>(impl_);
     b->assist_tools = assist_tools_default;
+    b->assist_fast_forward_multiplier = std::clamp(
+        fast_forward_multiplier_default, 2, 10);
     const std::string base = std::string(dir) + "/";
 
     // keybinds.ini [player1] (recomp-ui generic format, scancode names).
@@ -1704,6 +1708,9 @@ void HostWindow::load_input_config(const char* dir,
                      [b](const char* key, const char* val) {
         if (SDL_strcasecmp(key, "assist_tools") == 0)
             b->assist_tools = std::atoi(val) != 0;
+        else if (SDL_strcasecmp(key, "assist_fast_forward_multiplier") == 0)
+            b->assist_fast_forward_multiplier = std::clamp(
+                std::atoi(val), 2, 10);
         else if (SDL_strcasecmp(key, "assist_rewind_key") == 0)
             b->assist_key[0] = static_cast<SDL_Scancode>(std::atoi(val));
         else if (SDL_strcasecmp(key, "assist_fast_key") == 0)
@@ -1718,6 +1725,12 @@ void HostWindow::load_input_config(const char* dir,
 bool HostWindow::assist_tools_enabled() const {
     if (!open_ || !impl_) return true;
     return static_cast<const Backend*>(impl_)->assist_tools;
+}
+
+int HostWindow::fast_forward_multiplier() const {
+    if (!open_ || !impl_) return 4;
+    return static_cast<const Backend*>(impl_)
+        ->assist_fast_forward_multiplier;
 }
 
 void HostWindow::set_fullscreen(int mode) {
@@ -2158,7 +2171,8 @@ bool HostWindow::drawable_size(int* /*width*/, int* /*height*/) const {
 void HostWindow::present(const uint8_t* /*rgb888*/) {}
 
 void HostWindow::load_input_config(const char* /*dir*/,
-                                   bool /*assist_tools_default*/) {}
+                                   bool /*assist_tools_default*/,
+                                   int /*fast_forward_multiplier_default*/) {}
 void HostWindow::set_fullscreen(int /*mode*/) {}
 int  HostWindow::fullscreen() const { return 0; }
 void HostWindow::adjust_scale(int /*delta*/) {}
@@ -2176,6 +2190,7 @@ void HostWindow::set_runtime_ui(RecompRuntimeUi* /*ui*/) {}
 void HostWindow::set_fps_readout(bool /*on*/) {}
 bool HostWindow::fps_readout() const { return false; }
 bool HostWindow::assist_tools_enabled() const { return true; }
+int HostWindow::fast_forward_multiplier() const { return 4; }
 
 void HostWindow::push_audio_samples(const int16_t* /*samples*/,
                                     std::size_t /*count*/) {}

--- a/src/runtime/host_window.cpp
+++ b/src/runtime/host_window.cpp
@@ -334,6 +334,7 @@ struct Backend {
     int base_h = 160;   // logical surface height (160; vertical expansion deferred)
     bool expanded_view = false;  // native games retain the historical SDL path
     bool resize_driven_view = false;
+    bool freely_resizable_window = false;
     bool linear_filter = false;
     bool sharp_filter = false;
 
@@ -998,7 +999,8 @@ bool HostWindow::is_available() { return true; }
 
 bool HostWindow::open(int scale, int base_w, int base_h, const char* title,
                       const char* screen, bool linear_filter, bool sharp_filter,
-                      bool resize_driven_view) {
+                      bool resize_driven_view,
+                      bool freely_resizable_window) {
     if (open_) return true;
     if (scale < 1) scale = 1;
     if (base_w < 1) base_w = 240;
@@ -1044,6 +1046,7 @@ bool HostWindow::open(int scale, int base_w, int base_h, const char* title,
     b->base_h = base_h;
     b->expanded_view = base_w != 240 || base_h != 160;
     b->resize_driven_view = resize_driven_view;
+    b->freely_resizable_window = freely_resizable_window;
     b->linear_filter = linear_filter && !sharp_filter;
     b->sharp_filter = sharp_filter;
     b->scale = scale;
@@ -1062,7 +1065,8 @@ bool HostWindow::open(int scale, int base_w, int base_h, const char* title,
     const int win_w = base_w * scale;
     const int win_h = base_h * scale;
     Uint32 window_flags = SDL_WINDOW_SHOWN |
-        ((b->expanded_view || b->resize_driven_view)
+        ((b->expanded_view || b->resize_driven_view ||
+          b->freely_resizable_window)
              ? static_cast<Uint32>(SDL_WINDOW_RESIZABLE) : Uint32{0});
 #if defined(__ANDROID__)
     SDL_SetHint(SDL_HINT_ORIENTATIONS, "LandscapeLeft LandscapeRight");
@@ -1757,7 +1761,10 @@ void HostWindow::set_resize_driven_view(bool enabled) {
     if (!open_ || !impl_) return;
     auto* b = static_cast<Backend*>(impl_);
     b->resize_driven_view = enabled;
-    SDL_SetWindowResizable(b->window, enabled || b->expanded_view ? SDL_TRUE : SDL_FALSE);
+    SDL_SetWindowResizable(
+        b->window,
+        enabled || b->expanded_view || b->freely_resizable_window
+            ? SDL_TRUE : SDL_FALSE);
 }
 
 #if defined(GBARECOMP_RUNTIME_UI)
@@ -2051,7 +2058,8 @@ bool HostWindow::is_available() { return false; }
 bool HostWindow::open(int /*scale*/, int /*base_w*/, int /*base_h*/,
                       const char* /*title*/, const char* /*screen*/,
                       bool /*linear_filter*/, bool /*sharp_filter*/,
-                      bool /*resize_driven_view*/) {
+                      bool /*resize_driven_view*/,
+                      bool /*freely_resizable_window*/) {
     std::fprintf(stderr,
                  "host_window: built without SDL2; --window unavailable\n");
     return false;

--- a/src/runtime/host_window.cpp
+++ b/src/runtime/host_window.cpp
@@ -73,6 +73,30 @@ struct HotkeyBind {
     Uint16      mods = 0;             // required KMOD_CTRL/ALT/SHIFT bits
 };
 
+constexpr int assist_pad_axis(int code, bool positive) {
+    return 100 + code * 2 + (positive ? 1 : 0);
+}
+
+bool assist_pad_down(SDL_GameController* controller, int binding) {
+    if (!controller || !SDL_GameControllerGetAttached(controller)) return false;
+    if (binding > 0 && binding < 100) {
+        const int code = binding - 1;
+        return code >= 0 && code < SDL_CONTROLLER_BUTTON_MAX &&
+               SDL_GameControllerGetButton(
+                   controller, static_cast<SDL_GameControllerButton>(code));
+    }
+    if (binding >= 100) {
+        const int encoded = binding - 100;
+        const int code = encoded / 2;
+        const bool positive = (encoded & 1) != 0;
+        if (code < 0 || code >= SDL_CONTROLLER_AXIS_MAX) return false;
+        const Sint16 value = SDL_GameControllerGetAxis(
+            controller, static_cast<SDL_GameControllerAxis>(code));
+        return positive ? value >= 16000 : value <= -16000;
+    }
+    return false;
+}
+
 // ── MC-WS-002 present-cadence ring ───────────────────────────────────────
 // Always-on (Release too) ring recording EVERY SDL_RenderPresent from window
 // open: wall time blocked inside the call, entry-to-entry gap, and the DWM
@@ -343,6 +367,16 @@ struct Backend {
     // built-in defaults, overridden by keybinds.ini [player1].
     SDL_Scancode bind_sc[10] = {};      // indexed by GBA KEYINPUT bit
     HotkeyBind   hotkeys[HK_COUNT];     // [KeyMap] bindings
+    SDL_Scancode assist_key[2] = {
+        SDL_SCANCODE_1, SDL_SCANCODE_2
+    };                                  // Rewind, Fast-forward
+    int          assist_pad[2] = {
+        assist_pad_axis(SDL_CONTROLLER_AXIS_TRIGGERLEFT, true),
+        assist_pad_axis(SDL_CONTROLLER_AXIS_TRIGGERRIGHT, true),
+    };
+    bool         assist_tools = true;
+    bool         assist_rewind_was_down = false;
+    Uint32       assist_rewind_repeat_at = 0;
     int          scale = 3;             // current integer window scale
     int          fullscreen = 0;        // 0 windowed, 1 borderless, 2 exclusive
     int          volume = 100;          // 0..100 gain on pushed samples
@@ -1634,9 +1668,11 @@ void HostWindow::present(const uint8_t* rgb888) {
     }
 }
 
-void HostWindow::load_input_config(const char* dir) {
+void HostWindow::load_input_config(const char* dir,
+                                   bool assist_tools_default) {
     if (!open_ || !impl_ || !dir) return;
     auto* b = static_cast<Backend*>(impl_);
+    b->assist_tools = assist_tools_default;
     const std::string base = std::string(dir) + "/";
 
     // keybinds.ini [player1] (recomp-ui generic format, scancode names).
@@ -1659,6 +1695,29 @@ void HostWindow::load_input_config(const char* dir) {
             return;
         }
     });
+
+    // Launcher-owned global Assist bindings. Numeric keyboard values are SDL
+    // scancodes; controller values use recomp-ui's portable button/axis
+    // encoding. Keeping these in [Launcher] lets the pre-boot menu and the
+    // runtime share one configuration file.
+    ini_scan_section((base + "config.ini").c_str(), "Launcher",
+                     [b](const char* key, const char* val) {
+        if (SDL_strcasecmp(key, "assist_tools") == 0)
+            b->assist_tools = std::atoi(val) != 0;
+        else if (SDL_strcasecmp(key, "assist_rewind_key") == 0)
+            b->assist_key[0] = static_cast<SDL_Scancode>(std::atoi(val));
+        else if (SDL_strcasecmp(key, "assist_fast_key") == 0)
+            b->assist_key[1] = static_cast<SDL_Scancode>(std::atoi(val));
+        else if (SDL_strcasecmp(key, "assist_rewind_pad") == 0)
+            b->assist_pad[0] = std::atoi(val);
+        else if (SDL_strcasecmp(key, "assist_fast_pad") == 0)
+            b->assist_pad[1] = std::atoi(val);
+    });
+}
+
+bool HostWindow::assist_tools_enabled() const {
+    if (!open_ || !impl_) return true;
+    return static_cast<const Backend*>(impl_)->assist_tools;
 }
 
 void HostWindow::set_fullscreen(int mode) {
@@ -2030,7 +2089,9 @@ HostWindow::Events HostWindow::pump() {
     }
 #endif
 
-    // Turbo is level-triggered: held = uncap the frame limiter (default Tab).
+    // Turbo is level-triggered: held = uncap the frame limiter. The historical
+    // [KeyMap] Turbo binding (default Tab) remains as a compatibility shortcut;
+    // the launcher-editable Assist binding is additive.
     ev.fast_forward = false;
     {
         const HotkeyBind& hb = b->hotkeys[HK_TURBO];
@@ -2041,6 +2102,25 @@ HostWindow::Events HostWindow::pump() {
                 ev.fast_forward = true;
         }
     }
+    // Always report the configured physical controls. The runtime owns the
+    // Assist gate, which lets its in-game menu enable or disable these actions
+    // immediately without HostWindow carrying a stale copy of that live state.
+    const SDL_Scancode fast_sc = b->assist_key[1];
+    if ((fast_sc > SDL_SCANCODE_UNKNOWN && fast_sc < SDL_NUM_SCANCODES &&
+         ks[fast_sc]) || assist_pad_down(b->controller, b->assist_pad[1]))
+        ev.fast_forward = true;
+
+    const SDL_Scancode rewind_sc = b->assist_key[0];
+    const bool rewind_down =
+        (rewind_sc > SDL_SCANCODE_UNKNOWN && rewind_sc < SDL_NUM_SCANCODES &&
+         ks[rewind_sc]) || assist_pad_down(b->controller, b->assist_pad[0]);
+    const Uint32 rewind_now = SDL_GetTicks();
+    ev.rewind = rewind_down &&
+        (!b->assist_rewind_was_down ||
+         SDL_TICKS_PASSED(rewind_now, b->assist_rewind_repeat_at));
+    if (ev.rewind) b->assist_rewind_repeat_at = rewind_now + 500;
+    if (!rewind_down) b->assist_rewind_repeat_at = 0;
+    b->assist_rewind_was_down = rewind_down;
     return ev;
 }
 
@@ -2077,7 +2157,8 @@ bool HostWindow::drawable_size(int* /*width*/, int* /*height*/) const {
 
 void HostWindow::present(const uint8_t* /*rgb888*/) {}
 
-void HostWindow::load_input_config(const char* /*dir*/) {}
+void HostWindow::load_input_config(const char* /*dir*/,
+                                   bool /*assist_tools_default*/) {}
 void HostWindow::set_fullscreen(int /*mode*/) {}
 int  HostWindow::fullscreen() const { return 0; }
 void HostWindow::adjust_scale(int /*delta*/) {}
@@ -2094,6 +2175,7 @@ void HostWindow::set_runtime_ui(RecompRuntimeUi* /*ui*/) {}
 #endif
 void HostWindow::set_fps_readout(bool /*on*/) {}
 bool HostWindow::fps_readout() const { return false; }
+bool HostWindow::assist_tools_enabled() const { return true; }
 
 void HostWindow::push_audio_samples(const int16_t* /*samples*/,
                                     std::size_t /*count*/) {}

--- a/src/runtime/host_window.h
+++ b/src/runtime/host_window.h
@@ -68,7 +68,8 @@ public:
     // Never called => built-in defaults for both. Safe to call when the
     // files don't exist.
     void load_input_config(const char* dir,
-                           bool assist_tools_default = true);
+                           bool assist_tools_default = true,
+                           int fast_forward_multiplier_default = 4);
 
     // Live window/audio controls (hotkey + launcher-driven). All no-ops when
     // the window isn't open or this build has no SDL2.
@@ -94,6 +95,7 @@ public:
     void set_fps_readout(bool on);      // presents-per-second in the title bar
     bool fps_readout() const;
     bool assist_tools_enabled() const;
+    int  fast_forward_multiplier() const;
 
     // Upload one base_w x base_h RGB888 frame (the dimensions passed to open())
     // and present.

--- a/src/runtime/host_window.h
+++ b/src/runtime/host_window.h
@@ -44,7 +44,8 @@ public:
     bool open(int scale = 3, int base_w = 240, int base_h = 160,
               const char* title = "gbarecomp", const char* screen = nullptr,
               bool linear_filter = false, bool sharp_filter = false,
-              bool resize_driven_view = false);
+              bool resize_driven_view = false,
+              bool freely_resizable_window = false);
     void close();
     bool is_open() const { return open_; }
 

--- a/src/runtime/host_window.h
+++ b/src/runtime/host_window.h
@@ -67,7 +67,8 @@ public:
     //     WindowBigger, WindowSmaller, VolumeUp, VolumeDown, DisplayPerf.
     // Never called => built-in defaults for both. Safe to call when the
     // files don't exist.
-    void load_input_config(const char* dir);
+    void load_input_config(const char* dir,
+                           bool assist_tools_default = true);
 
     // Live window/audio controls (hotkey + launcher-driven). All no-ops when
     // the window isn't open or this build has no SDL2.
@@ -92,6 +93,7 @@ public:
 #endif
     void set_fps_readout(bool on);      // presents-per-second in the title bar
     bool fps_readout() const;
+    bool assist_tools_enabled() const;
 
     // Upload one base_w x base_h RGB888 frame (the dimensions passed to open())
     // and present.
@@ -127,6 +129,10 @@ public:
         // held (default Tab). Uncaps the frame limiter for as long as it's
         // down.
         bool     fast_forward = false;
+        // Repeating global Assist binding. It fires immediately, then every
+        // half-second while held so one-second rewind steps move backward at
+        // approximately normal speed.
+        bool     rewind = false;
         // Edge-triggered system hotkeys (config.ini [KeyMap] bindings; see
         // load_input_config). The caller owns the semantics: fullscreen and
         // window scale route back into this window, pause gates stepping in

--- a/src/runtime/launcher_seam.h
+++ b/src/runtime/launcher_seam.h
@@ -329,6 +329,11 @@ struct SeamConfig {
     int  aspect_index = 0;     // games with a launcher_aspect vocabulary only
     int  adaptive_view = 0;    // live drawable aspect; fixed aspect is retained
     float gyro_sensitivity = 1.00f;
+    int  assist_tools = -1;      // unset -> game's requested default
+    int  assist_rewind_key = 30; // SDL_SCANCODE_1
+    int  assist_fast_key = 31;   // SDL_SCANCODE_2
+    int  assist_rewind_pad = RECOMP_LAUNCHER_PAD_AXIS(4, 1); // left trigger
+    int  assist_fast_pad = RECOMP_LAUNCHER_PAD_AXIS(5, 1);   // right trigger
 };
 
 inline void seam_config_load(const std::string& path, SeamConfig* c) {
@@ -370,6 +375,11 @@ inline void seam_config_load(const std::string& path, SeamConfig* c) {
         else if (key == "adaptive_view") c->adaptive_view = std::atoi(val.c_str());
         else if (key == "gyro_sensitivity")
             c->gyro_sensitivity = std::strtof(val.c_str(), nullptr);
+        else if (key == "assist_tools") c->assist_tools = std::atoi(val.c_str());
+        else if (key == "assist_rewind_key") c->assist_rewind_key = std::atoi(val.c_str());
+        else if (key == "assist_fast_key") c->assist_fast_key = std::atoi(val.c_str());
+        else if (key == "assist_rewind_pad") c->assist_rewind_pad = std::atoi(val.c_str());
+        else if (key == "assist_fast_pad") c->assist_fast_pad = std::atoi(val.c_str());
     }
     if (c->scale < 1) c->scale = 1;
     if (c->scale > 8) c->scale = 8;
@@ -381,6 +391,8 @@ inline void seam_config_load(const std::string& path, SeamConfig* c) {
     if (c->fullscreen < 0 || c->fullscreen > 2) c->fullscreen = 0;
     if (c->gyro_sensitivity < 0.25f) c->gyro_sensitivity = 0.25f;
     if (c->gyro_sensitivity > 4.00f) c->gyro_sensitivity = 4.00f;
+    if (c->assist_tools > 1) c->assist_tools = 1;
+    if (c->assist_tools < -1) c->assist_tools = -1;
 }
 
 // Rewrite ONLY the [Launcher] section of config.ini, preserving every other
@@ -425,6 +437,11 @@ inline void seam_config_save(const std::string& path, const SeamConfig& c) {
     f << "aspect_index = " << c.aspect_index << "\n";
     f << "adaptive_view = " << c.adaptive_view << "\n";
     f << "gyro_sensitivity = " << c.gyro_sensitivity << "\n";
+    f << "assist_tools = " << c.assist_tools << "\n";
+    f << "assist_rewind_key = " << c.assist_rewind_key << "\n";
+    f << "assist_fast_key = " << c.assist_fast_key << "\n";
+    f << "assist_rewind_pad = " << c.assist_rewind_pad << "\n";
+    f << "assist_fast_pad = " << c.assist_fast_pad << "\n";
 }
 
 // ---- config.ini [Solar] ------------------------------------------------------
@@ -658,6 +675,8 @@ inline int gbarecomp_launcher_preboot(std::vector<std::string>& args,
         cfg.sharp_filter = opts.launcher_default_sharp_filter ? 1 : 0;
     if (cfg.affine_filter < 0)
         cfg.affine_filter = opts.launcher_default_affine_filter ? 1 : 0;
+    if (cfg.assist_tools < 0)
+        cfg.assist_tools = opts.assist_tools_enabled_by_default ? 1 : 0;
     SeamSolar solar;
     if (opts.has_solar_sensor) seam_solar_load(config_path, &solar);
     if (cfg.skip_launcher && !force_launcher) {
@@ -738,6 +757,11 @@ inline int gbarecomp_launcher_preboot(std::vector<std::string>& args,
     if (opts.has_solar_sensor) solar_in_launcher = push_solar_settings(ls, solar);
     ls.screen_kind   = cfg.screen_kind;
     ls.aspect_index  = cfg.aspect_index;
+    ls.assist_tools = cfg.assist_tools;
+    ls.assist_key_bind[0] = cfg.assist_rewind_key;
+    ls.assist_key_bind[1] = cfg.assist_fast_key;
+    ls.assist_pad_bind[0] = cfg.assist_rewind_pad;
+    ls.assist_pad_bind[1] = cfg.assist_fast_pad;
     gbarecomp_seam::set_gyro_sensitivity(ls, cfg.gyro_sensitivity);
     gbarecomp_seam::set_presentation_filters(
         ls, cfg.sharp_filter != 0, cfg.affine_filter != 0);
@@ -765,6 +789,25 @@ inline int gbarecomp_launcher_preboot(std::vector<std::string>& args,
         opts.resize_driven_view && opts.max_resize_view_width > 240 ? 1 : 0;
     gi.config_path = config_path.c_str();
     gi.keybinds_path = keybinds_path.c_str();
+    static const char* const kAssistBindings[] = {
+        "Rewind", "Fast-forward"
+    };
+    static const int kAssistDefaultKeys[RECOMP_LAUNCHER_MAX_ASSIST_BINDINGS] = {
+        30, 31 /* SDL_SCANCODE_1, SDL_SCANCODE_2 */
+    };
+    static const int kAssistDefaultPads[RECOMP_LAUNCHER_MAX_ASSIST_BINDINGS] = {
+        RECOMP_LAUNCHER_PAD_AXIS(4, 1),
+        RECOMP_LAUNCHER_PAD_AXIS(5, 1),
+    };
+    gi.has_assist_tools = opts.expose_assist_tools ? 1 : 0;
+    gi.assist_tools_note =
+        "Rewind returns to a recent point kept in memory. Fast-forward runs "
+        "without the normal frame limiter. Keyboard and controller controls "
+        "can be changed below.";
+    gi.assist_binding_labels = kAssistBindings;
+    gi.assist_binding_count = opts.expose_assist_tools ? 2 : 0;
+    gi.assist_default_key_bind = kAssistDefaultKeys;
+    gi.assist_default_pad_bind = kAssistDefaultPads;
     gi.boxart_path = opts.launcher_boxart;   // NULL => default assets/img/boxart.tga
     gi.bios_verify = &gbarecomp_seam::verify_retail_gba_bios;
     gbarecomp_seam::set_has_gyro_controls(gi, opts.launcher_expose_gyro);
@@ -830,6 +873,11 @@ inline int gbarecomp_launcher_preboot(std::vector<std::string>& args,
         std::clamp(gbarecomp_seam::get_gyro_sensitivity(
                        ls, cfg.gyro_sensitivity),
                    0.25f, 4.00f);
+    cfg.assist_tools = ls.assist_tools ? 1 : 0;
+    cfg.assist_rewind_key = ls.assist_key_bind[0];
+    cfg.assist_fast_key = ls.assist_key_bind[1];
+    cfg.assist_rewind_pad = ls.assist_pad_bind[0];
+    cfg.assist_fast_pad = ls.assist_pad_bind[1];
     seam_config_save(config_path, cfg);
     // Only rewrite [Solar] when this recomp-ui pin actually surfaced the panel;
     // otherwise the values never round-tripped through it and writing them back

--- a/src/runtime/launcher_seam.h
+++ b/src/runtime/launcher_seam.h
@@ -330,6 +330,7 @@ struct SeamConfig {
     int  adaptive_view = 0;    // live drawable aspect; fixed aspect is retained
     float gyro_sensitivity = 1.00f;
     int  assist_tools = -1;      // unset -> game's requested default
+    int  assist_fast_forward_multiplier = 0; // unset -> game default
     int  assist_rewind_key = 30; // SDL_SCANCODE_1
     int  assist_fast_key = 31;   // SDL_SCANCODE_2
     int  assist_rewind_pad = RECOMP_LAUNCHER_PAD_AXIS(4, 1); // left trigger
@@ -376,6 +377,8 @@ inline void seam_config_load(const std::string& path, SeamConfig* c) {
         else if (key == "gyro_sensitivity")
             c->gyro_sensitivity = std::strtof(val.c_str(), nullptr);
         else if (key == "assist_tools") c->assist_tools = std::atoi(val.c_str());
+        else if (key == "assist_fast_forward_multiplier")
+            c->assist_fast_forward_multiplier = std::atoi(val.c_str());
         else if (key == "assist_rewind_key") c->assist_rewind_key = std::atoi(val.c_str());
         else if (key == "assist_fast_key") c->assist_fast_key = std::atoi(val.c_str());
         else if (key == "assist_rewind_pad") c->assist_rewind_pad = std::atoi(val.c_str());
@@ -438,6 +441,8 @@ inline void seam_config_save(const std::string& path, const SeamConfig& c) {
     f << "adaptive_view = " << c.adaptive_view << "\n";
     f << "gyro_sensitivity = " << c.gyro_sensitivity << "\n";
     f << "assist_tools = " << c.assist_tools << "\n";
+    f << "assist_fast_forward_multiplier = "
+      << c.assist_fast_forward_multiplier << "\n";
     f << "assist_rewind_key = " << c.assist_rewind_key << "\n";
     f << "assist_fast_key = " << c.assist_fast_key << "\n";
     f << "assist_rewind_pad = " << c.assist_rewind_pad << "\n";
@@ -677,6 +682,10 @@ inline int gbarecomp_launcher_preboot(std::vector<std::string>& args,
         cfg.affine_filter = opts.launcher_default_affine_filter ? 1 : 0;
     if (cfg.assist_tools < 0)
         cfg.assist_tools = opts.assist_tools_enabled_by_default ? 1 : 0;
+    if (cfg.assist_fast_forward_multiplier < 2 ||
+        cfg.assist_fast_forward_multiplier > 10)
+        cfg.assist_fast_forward_multiplier = std::clamp<int>(
+            opts.assist_fast_forward_multiplier_default, 2, 10);
     SeamSolar solar;
     if (opts.has_solar_sensor) seam_solar_load(config_path, &solar);
     if (cfg.skip_launcher && !force_launcher) {
@@ -758,6 +767,8 @@ inline int gbarecomp_launcher_preboot(std::vector<std::string>& args,
     ls.screen_kind   = cfg.screen_kind;
     ls.aspect_index  = cfg.aspect_index;
     ls.assist_tools = cfg.assist_tools;
+    ls.assist_fast_forward_multiplier =
+        cfg.assist_fast_forward_multiplier;
     ls.assist_key_bind[0] = cfg.assist_rewind_key;
     ls.assist_key_bind[1] = cfg.assist_fast_key;
     ls.assist_pad_bind[0] = cfg.assist_rewind_pad;
@@ -808,6 +819,8 @@ inline int gbarecomp_launcher_preboot(std::vector<std::string>& args,
     gi.assist_binding_count = opts.expose_assist_tools ? 2 : 0;
     gi.assist_default_key_bind = kAssistDefaultKeys;
     gi.assist_default_pad_bind = kAssistDefaultPads;
+    gi.assist_fast_forward_min = 2;
+    gi.assist_fast_forward_max = 10;
     gi.boxart_path = opts.launcher_boxart;   // NULL => default assets/img/boxart.tga
     gi.bios_verify = &gbarecomp_seam::verify_retail_gba_bios;
     gbarecomp_seam::set_has_gyro_controls(gi, opts.launcher_expose_gyro);
@@ -874,6 +887,8 @@ inline int gbarecomp_launcher_preboot(std::vector<std::string>& args,
                        ls, cfg.gyro_sensitivity),
                    0.25f, 4.00f);
     cfg.assist_tools = ls.assist_tools ? 1 : 0;
+    cfg.assist_fast_forward_multiplier = std::clamp(
+        ls.assist_fast_forward_multiplier, 2, 10);
     cfg.assist_rewind_key = ls.assist_key_bind[0];
     cfg.assist_fast_key = ls.assist_key_bind[1];
     cfg.assist_rewind_pad = ls.assist_pad_bind[0];

--- a/src/runtime/launcher_seam.h
+++ b/src/runtime/launcher_seam.h
@@ -335,6 +335,8 @@ struct SeamConfig {
     int  assist_fast_key = 31;   // SDL_SCANCODE_2
     int  assist_rewind_pad = RECOMP_LAUNCHER_PAD_AXIS(4, 1); // left trigger
     int  assist_fast_pad = RECOMP_LAUNCHER_PAD_AXIS(5, 1);   // right trigger
+    int  rom_patch_enabled = 0;
+    std::string rom_patch_path;
 };
 
 inline void seam_config_load(const std::string& path, SeamConfig* c) {
@@ -383,6 +385,8 @@ inline void seam_config_load(const std::string& path, SeamConfig* c) {
         else if (key == "assist_fast_key") c->assist_fast_key = std::atoi(val.c_str());
         else if (key == "assist_rewind_pad") c->assist_rewind_pad = std::atoi(val.c_str());
         else if (key == "assist_fast_pad") c->assist_fast_pad = std::atoi(val.c_str());
+        else if (key == "rom_patch_enabled") c->rom_patch_enabled = std::atoi(val.c_str());
+        else if (key == "rom_patch_path") c->rom_patch_path = val;
     }
     if (c->scale < 1) c->scale = 1;
     if (c->scale > 8) c->scale = 8;
@@ -396,6 +400,7 @@ inline void seam_config_load(const std::string& path, SeamConfig* c) {
     if (c->gyro_sensitivity > 4.00f) c->gyro_sensitivity = 4.00f;
     if (c->assist_tools > 1) c->assist_tools = 1;
     if (c->assist_tools < -1) c->assist_tools = -1;
+    c->rom_patch_enabled = c->rom_patch_enabled && !c->rom_patch_path.empty();
 }
 
 // Rewrite ONLY the [Launcher] section of config.ini, preserving every other
@@ -447,6 +452,8 @@ inline void seam_config_save(const std::string& path, const SeamConfig& c) {
     f << "assist_fast_key = " << c.assist_fast_key << "\n";
     f << "assist_rewind_pad = " << c.assist_rewind_pad << "\n";
     f << "assist_fast_pad = " << c.assist_fast_pad << "\n";
+    f << "rom_patch_enabled = " << c.rom_patch_enabled << "\n";
+    f << "rom_patch_path = " << c.rom_patch_path << "\n";
 }
 
 // ---- config.ini [Solar] ------------------------------------------------------
@@ -688,7 +695,8 @@ inline int gbarecomp_launcher_preboot(std::vector<std::string>& args,
             opts.assist_fast_forward_multiplier_default, 2, 10);
     SeamSolar solar;
     if (opts.has_solar_sensor) seam_solar_load(config_path, &solar);
-    if (cfg.skip_launcher && !force_launcher) {
+    if (cfg.skip_launcher && !force_launcher &&
+        !(opts.launcher_enable_rom_patches && cfg.rom_patch_enabled)) {
         // Boot straight in, but still honor the persisted settings.
         seam_append_setting_args(args, cfg, opts);
         return 0;
@@ -773,10 +781,25 @@ inline int gbarecomp_launcher_preboot(std::vector<std::string>& args,
     ls.assist_key_bind[1] = cfg.assist_fast_key;
     ls.assist_pad_bind[0] = cfg.assist_rewind_pad;
     ls.assist_pad_bind[1] = cfg.assist_fast_pad;
+    ls.rom_patch_enabled = cfg.rom_patch_enabled;
+    std::snprintf(ls.rom_patch_path, sizeof(ls.rom_patch_path), "%s",
+                  cfg.rom_patch_path.c_str());
     gbarecomp_seam::set_gyro_sensitivity(ls, cfg.gyro_sensitivity);
     gbarecomp_seam::set_presentation_filters(
         ls, cfg.sharp_filter != 0, cfg.affine_filter != 0);
     std::snprintf(ls.bios_path, sizeof(ls.bios_path), "%s", seed_bios.c_str());
+
+    std::string rom_patch_cache_dir;
+    if (opts.launcher_enable_rom_patches) {
+        const std::filesystem::path cache =
+            std::filesystem::path(dir) / "mods" / "rom-patches";
+        std::error_code cache_error;
+        std::filesystem::create_directories(cache, cache_error);
+        if (!cache_error) rom_patch_cache_dir = cache.string();
+        else std::fprintf(stderr,
+                          "[gbarecomp:launcher] patch cache unavailable: %s\n",
+                          cache_error.message().c_str());
+    }
 
     RecompLauncherCGameInfo gi;
     std::memset(&gi, 0, sizeof(gi));
@@ -788,8 +811,10 @@ inline int gbarecomp_launcher_preboot(std::vector<std::string>& args,
     // CRC32 is dump-specific and would reject other valid dumps). CRC32, when
     // present, stays informational only.
     const char* sha1_one[1];
-    if (opts.builtin_rom_sha1 && opts.builtin_rom_sha1[0]) {
-        sha1_one[0] = opts.builtin_rom_sha1;
+    const char* launcher_source_sha1 = opts.launcher_source_rom_sha1
+        ? opts.launcher_source_rom_sha1 : opts.builtin_rom_sha1;
+    if (launcher_source_sha1 && launcher_source_sha1[0]) {
+        sha1_one[0] = launcher_source_sha1;
         gi.known_sha1_hex = sha1_one;
         gi.num_known_sha1 = 1;
     }
@@ -823,6 +848,11 @@ inline int gbarecomp_launcher_preboot(std::vector<std::string>& args,
     gi.assist_fast_forward_max = 10;
     gi.boxart_path = opts.launcher_boxart;   // NULL => default assets/img/boxart.tga
     gi.bios_verify = &gbarecomp_seam::verify_retail_gba_bios;
+    gi.rom_patch_supported =
+        opts.launcher_enable_rom_patches && !rom_patch_cache_dir.empty();
+    gi.rom_patch_note = opts.launcher_rom_patch_note;
+    gi.rom_patch_cache_dir = rom_patch_cache_dir.c_str();
+    gi.rom_patch_required_sha1 = opts.launcher_required_patch_sha1;
     gbarecomp_seam::set_has_gyro_controls(gi, opts.launcher_expose_gyro);
     gbarecomp_seam::set_presentation_filter_caps(
         gi, opts.launcher_expose_sharp_filter,
@@ -893,6 +923,8 @@ inline int gbarecomp_launcher_preboot(std::vector<std::string>& args,
     cfg.assist_fast_key = ls.assist_key_bind[1];
     cfg.assist_rewind_pad = ls.assist_pad_bind[0];
     cfg.assist_fast_pad = ls.assist_pad_bind[1];
+    cfg.rom_patch_enabled = ls.rom_patch_enabled ? 1 : 0;
+    cfg.rom_patch_path = ls.rom_patch_path;
     seam_config_save(config_path, cfg);
     // Only rewrite [Solar] when this recomp-ui pin actually surfaced the panel;
     // otherwise the values never round-tripped through it and writing them back
@@ -903,10 +935,20 @@ inline int gbarecomp_launcher_preboot(std::vector<std::string>& args,
     if (picked_rom[0]) {
         args.push_back("--rom");
         args.push_back(picked_rom);
+        if (ls.rom_patch_enabled && ls.rom_patch_sha1[0]) {
+            args.push_back("--rom-sha1");
+            args.push_back(ls.rom_patch_sha1);
+            if (ls.rom_patch_crc32[0]) {
+                args.push_back("--rom-crc32");
+                args.push_back(ls.rom_patch_crc32);
+            }
+        }
         // Persist the pick NOW (not only after a successful boot) so the next
         // launch prefills instead of re-prompting — the whole point of the
         // launcher remembering. Mirrors the runtime asset picker's cache.
-        write_single_line(rom_cfg, picked_rom);
+        write_single_line(rom_cfg,
+            ls.rom_patch_source_path[0]
+                ? ls.rom_patch_source_path : picked_rom);
     }
     if (ls.bios_path[0]) {
         args.push_back("--bios");

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -63,6 +63,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <deque>
 #include <filesystem>
 #include <fstream>
 #include <limits>
@@ -204,6 +205,9 @@ struct Args {
 // menu exists to replace.
 #define GBARECOMP_UI_KEY_STATE_SLOT "system.state_slot"
 #define GBARECOMP_UI_KEY_FPS        "display.fps_readout"
+#define GBARECOMP_UI_KEY_ASSIST_ENABLED "assist.enabled"
+#define GBARECOMP_UI_KEY_FAST_FORWARD   "assist.fast_forward"
+#define GBARECOMP_UI_KEY_REWIND          "assist.rewind"
 
 struct RuntimeUiContext {
     HostWindow* window = nullptr;
@@ -214,8 +218,13 @@ struct RuntimeUiContext {
     // Menu-driven state slots, drained by the main loop alongside the
     // equivalent hotkeys so both paths share one implementation.
     int state_slot = 1;
+    int state_slot_count = 9;
     int pending_save_slot = 0;
     int pending_load_slot = 0;
+    bool pending_rewind = false;
+    bool assist_tools_exposed = false;
+    bool assist_tools_enabled = true;
+    bool fast_forward_latched = false;
     // Game-supplied handlers for keys the engine does not own.
     const RunOptions* opts = nullptr;
 };
@@ -231,6 +240,10 @@ int runtime_ui_get(void* opaque, const RecompRuntimeUiItem* item, int* out) {
     else if (std::strcmp(item->key, RECOMP_RUNTIME_UI_KEY_VOLUME) == 0) *out = c->window->volume();
     else if (std::strcmp(item->key, GBARECOMP_UI_KEY_STATE_SLOT) == 0) *out = c->state_slot;
     else if (std::strcmp(item->key, GBARECOMP_UI_KEY_FPS) == 0) *out = c->window->fps_readout();
+    else if (std::strcmp(item->key, GBARECOMP_UI_KEY_ASSIST_ENABLED) == 0)
+        *out = c->assist_tools_enabled;
+    else if (std::strcmp(item->key, GBARECOMP_UI_KEY_FAST_FORWARD) == 0)
+        *out = c->fast_forward_latched;
 #if defined(RECOMP_RUNTIME_UI_KEY_GYRO_SENSITIVITY)
     else if (std::strcmp(item->key, RECOMP_RUNTIME_UI_KEY_GYRO_SENSITIVITY) == 0 &&
              c->gyro_sensitivity)
@@ -257,9 +270,14 @@ int runtime_ui_set(void* opaque, const RecompRuntimeUiItem* item, int value) {
     else if (std::strcmp(item->key, RECOMP_RUNTIME_UI_KEY_VOLUME) == 0)
         c->window->set_volume(value);
     else if (std::strcmp(item->key, GBARECOMP_UI_KEY_STATE_SLOT) == 0)
-        c->state_slot = (value < 1) ? 1 : (value > 9 ? 9 : value);
+        c->state_slot = std::clamp(value, 1, c->state_slot_count);
     else if (std::strcmp(item->key, GBARECOMP_UI_KEY_FPS) == 0)
         c->window->set_fps_readout(value != 0);
+    else if (std::strcmp(item->key, GBARECOMP_UI_KEY_ASSIST_ENABLED) == 0) {
+        c->assist_tools_enabled = value != 0;
+        if (!c->assist_tools_enabled) c->fast_forward_latched = false;
+    } else if (std::strcmp(item->key, GBARECOMP_UI_KEY_FAST_FORWARD) == 0)
+        c->fast_forward_latched = value != 0;
 #if defined(RECOMP_RUNTIME_UI_KEY_GYRO_SENSITIVITY)
     else if (std::strcmp(item->key, RECOMP_RUNTIME_UI_KEY_GYRO_SENSITIVITY) == 0 &&
              c->gyro_sensitivity)
@@ -288,6 +306,11 @@ int runtime_ui_action(void* opaque, const RecompRuntimeUiItem* item) {
     }
     if (std::strcmp(item->key, RECOMP_RUNTIME_UI_KEY_LOAD_STATE) == 0) {
         c->pending_load_slot = c->state_slot;
+        recomp_runtime_ui_close(c->ui);
+        return 1;
+    }
+    if (std::strcmp(item->key, GBARECOMP_UI_KEY_REWIND) == 0) {
+        c->pending_rewind = true;
         recomp_runtime_ui_close(c->ui);
         return 1;
     }
@@ -320,6 +343,13 @@ int runtime_ui_enabled(void* opaque, const RecompRuntimeUiItem* item) {
     if (!c || !item) return 1;
     if (std::strcmp(item->key, RECOMP_RUNTIME_UI_KEY_WINDOW_SCALE) == 0)
         return c->window->fullscreen() == 0;
+    if (c->assist_tools_exposed &&
+        std::strcmp(item->key, GBARECOMP_UI_KEY_ASSIST_ENABLED) != 0 &&
+        (std::strncmp(item->key, "assist.", 7) == 0 ||
+         std::strcmp(item->key, GBARECOMP_UI_KEY_STATE_SLOT) == 0 ||
+         std::strcmp(item->key, RECOMP_RUNTIME_UI_KEY_SAVE_STATE) == 0 ||
+         std::strcmp(item->key, RECOMP_RUNTIME_UI_KEY_LOAD_STATE) == 0))
+        return c->assist_tools_enabled;
     if (c->opts && c->opts->ui_enabled) return c->opts->ui_enabled(item->key);
     return 1;
 }
@@ -1952,6 +1982,22 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
         ++g_runtime_state_epoch;
         return true;
     };
+    auto do_savestate_save_bytes = [&](std::vector<uint8_t>& bytes,
+                                       std::string& e) -> bool {
+        return debug::save_state_bytes(&bytes, make_snapshot_ctx(), &e);
+    };
+    auto do_savestate_load_bytes = [&](const std::vector<uint8_t>& bytes,
+                                       std::string& e) -> bool {
+        if (!debug::load_state_bytes(bytes.data(), bytes.size(),
+                                     make_snapshot_ctx(), &e)) {
+            return false;
+        }
+        sync_frame_counter();
+        g_runtime_cycles = 0;
+        runtime_fp_reset();
+        ++g_runtime_state_epoch;
+        return true;
+    };
 
     // ── Differential-oracle WRAM trace (gbaref/snesref/mdref method) ──
     // GBARECOMP_WRAM_TRACE=path emits one JSONL record per changed work-RAM byte
@@ -2354,7 +2400,7 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
                       runtime_title,
                       args.screen.empty() ? nullptr : args.screen.c_str(),
                       args.linear_filter, args.sharp_filter,
-                      resize_view_enabled)) {
+                      resize_view_enabled, opts.freely_resizable_window)) {
             gbarecomp::overlay_loader_shutdown();
             runtime_shutdown();
             return 1;
@@ -2372,9 +2418,16 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
         }
         if (args.fullscreen) win.set_fullscreen(args.fullscreen);
         win.set_volume(args.volume);
+        win.set_fps_readout(opts.show_fps_by_default);
 #if defined(GBARECOMP_RUNTIME_UI)
         runtime_ui_context.window = &win;
         runtime_ui_context.gyro_sensitivity = &args.gyro_sensitivity;
+        runtime_ui_context.assist_tools_exposed = opts.expose_assist_tools;
+        runtime_ui_context.assist_tools_enabled =
+            opts.assist_tools_enabled_by_default;
+        runtime_ui_context.state_slot_count = std::clamp<int>(
+            opts.save_state_slot_count ? opts.save_state_slot_count : 9,
+            1, 10);
 #if defined(RECOMP_RUNTIME_UI_KEY_GYRO_SENSITIVITY)
         static const RecompRuntimeUiItem gyro_item{
             RECOMP_RUNTIME_UI_KEY_GYRO_SENSITIVITY,
@@ -2413,9 +2466,12 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
             RECOMP_RUNTIME_UI_STANDARD_LINEAR_FILTER |
             RECOMP_RUNTIME_UI_STANDARD_AUDIO |
             RECOMP_RUNTIME_UI_STANDARD_VOLUME |
-            RECOMP_RUNTIME_UI_STANDARD_SAVE_STATE |
-            RECOMP_RUNTIME_UI_STANDARD_LOAD_STATE |
             RECOMP_RUNTIME_UI_STANDARD_RESUME;
+        if (!opts.expose_assist_tools) {
+            runtime_ui_config.features |=
+                RECOMP_RUNTIME_UI_STANDARD_SAVE_STATE |
+                RECOMP_RUNTIME_UI_STANDARD_LOAD_STATE;
+        }
         // INTEGER_SCALE is deliberately absent: HostWindow::adjust_scale only
         // ever produces integer scales (clamped 1..8), so there is no
         // fractional mode for a toggle to switch off. Offering one would
@@ -2447,15 +2503,64 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
 #endif
         RecompRuntimeUiItem slot_item{};
         slot_item.key         = GBARECOMP_UI_KEY_STATE_SLOT;
-        slot_item.section     = "System";
+        slot_item.section     = opts.expose_assist_tools
+                                    ? "Assist Tools" : "System";
         slot_item.label       = "State slot";
         slot_item.description = "Slot used by Save state and Load state "
-                                "(same slots as F1-F9).";
+                                "(slots 1-9 also have function-key shortcuts).";
         slot_item.type        = RECOMP_RUNTIME_UI_INT;
         slot_item.minimum     = 1;
-        slot_item.maximum     = 9;
+        slot_item.maximum     = runtime_ui_context.state_slot_count;
         slot_item.step        = 1;
+        if (opts.expose_assist_tools) {
+            RecompRuntimeUiItem enabled_item{};
+            enabled_item.key         = GBARECOMP_UI_KEY_ASSIST_ENABLED;
+            enabled_item.section     = "Assist Tools";
+            enabled_item.label       = "Assist Tools";
+            enabled_item.description =
+                "Enable save states, fast-forward, and rewind.";
+            enabled_item.type        = RECOMP_RUNTIME_UI_BOOL;
+            runtime_ui_extras.push_back(enabled_item);
+        }
         runtime_ui_extras.push_back(slot_item);
+
+        if (opts.expose_assist_tools) {
+            RecompRuntimeUiItem save_item{};
+            save_item.key         = RECOMP_RUNTIME_UI_KEY_SAVE_STATE;
+            save_item.section     = "Assist Tools";
+            save_item.label       = "Save state";
+            save_item.description = "Save the current position to this slot.";
+            save_item.type        = RECOMP_RUNTIME_UI_ACTION;
+            runtime_ui_extras.push_back(save_item);
+
+            RecompRuntimeUiItem load_item{};
+            load_item.key         = RECOMP_RUNTIME_UI_KEY_LOAD_STATE;
+            load_item.section     = "Assist Tools";
+            load_item.label       = "Load state";
+            load_item.description = "Restore the selected state slot.";
+            load_item.type        = RECOMP_RUNTIME_UI_ACTION;
+            runtime_ui_extras.push_back(load_item);
+
+            RecompRuntimeUiItem fast_forward_item{};
+            fast_forward_item.key         = GBARECOMP_UI_KEY_FAST_FORWARD;
+            fast_forward_item.section     = "Assist Tools";
+            fast_forward_item.label       = "Fast-forward";
+            fast_forward_item.description =
+                "Run without the normal frame limiter until switched off.";
+            fast_forward_item.type        = RECOMP_RUNTIME_UI_BOOL;
+            runtime_ui_extras.push_back(fast_forward_item);
+
+            if (opts.rewind_history_seconds > 0) {
+                RecompRuntimeUiItem rewind_item{};
+                rewind_item.key         = GBARECOMP_UI_KEY_REWIND;
+                rewind_item.section     = "Assist Tools";
+                rewind_item.label       = "Rewind 1 second";
+                rewind_item.description =
+                    "Return to an earlier point kept in temporary memory.";
+                rewind_item.type        = RECOMP_RUNTIME_UI_ACTION;
+                runtime_ui_extras.push_back(rewind_item);
+            }
+        }
 
         RecompRuntimeUiItem fps_item{};
         fps_item.key         = GBARECOMP_UI_KEY_FPS;
@@ -2483,8 +2588,10 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
         pacer.emplace();  // paces to the GBA's 59.7275 Hz
     }
 
-    // Host-window save-state slots: the ROM path with a .stateN
-    // extension (N = 1..9). Shift+Fn writes slot N, Fn restores it.
+    // Host-window save-state slots: the ROM path with a .stateN extension.
+    // Shift+F1..F9 writes slots 1..9 and F1..F9 restores them; a runtime menu
+    // may additionally expose slot 10 without changing the established
+    // function-key shortcut scheme.
     auto slot_path = [&](int slot) -> std::string {
         std::filesystem::path p(args.rom);
         p.replace_extension(".state" + std::to_string(slot));
@@ -2492,6 +2599,48 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
     };
 
     uint64_t last_presented_frame = ppu.frame_count();
+
+    struct RewindPoint {
+        uint64_t frame = 0;
+        std::vector<uint8_t> state;
+    };
+    std::deque<RewindPoint> rewind_history;
+    const uint64_t rewind_interval = std::max<uint64_t>(
+        1, opts.rewind_capture_interval_frames);
+    const std::size_t rewind_capacity = opts.rewind_history_seconds == 0
+        ? 0
+        : static_cast<std::size_t>(
+              (static_cast<uint64_t>(opts.rewind_history_seconds) * 60u +
+               rewind_interval - 1u) / rewind_interval + 1u);
+    uint64_t next_rewind_capture_frame = ppu.frame_count();
+
+    auto assist_tools_enabled = [&]() -> bool {
+#if defined(GBARECOMP_RUNTIME_UI)
+        return !opts.expose_assist_tools ||
+               runtime_ui_context.assist_tools_enabled;
+#else
+        return true;
+#endif
+    };
+    auto capture_rewind_point = [&]() {
+        if (!rewind_capacity || !assist_tools_enabled()) return;
+        const uint64_t frame = ppu.frame_count();
+        if (frame < next_rewind_capture_frame) return;
+        RewindPoint point;
+        point.frame = frame;
+        std::string e;
+        if (!do_savestate_save_bytes(point.state, e)) {
+            std::fprintf(stderr,
+                         "[gbarecomp:runtime] rewind capture failed: %s\n",
+                         e.c_str());
+            next_rewind_capture_frame = frame + rewind_interval;
+            return;
+        }
+        rewind_history.push_back(std::move(point));
+        while (rewind_history.size() > rewind_capacity)
+            rewind_history.pop_front();
+        next_rewind_capture_frame = frame + rewind_interval;
+    };
 
     // Optional frame-indexed KEYINPUT trace. Interactive discovery records
     // every observed key-state change and flushes it immediately; strict
@@ -2594,6 +2743,7 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
 
     auto pump_host_input = [&]() {
         if (!args.window) return;
+        capture_rewind_point();
         auto ev = win.pump();
         if (!input_replay_requested) bus.io().set_keyinput(ev.keyinput);
         if (bus.gyro().active()) {
@@ -2648,7 +2798,15 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
                         step + 1, kSolarSteps[step]);
             std::fflush(stdout);
         }
-        if (pacer) pacer->set_uncapped(ev.fast_forward);
+        bool fast_forward_latched = false;
+#if defined(GBARECOMP_RUNTIME_UI)
+        fast_forward_latched = runtime_ui_context.fast_forward_latched;
+#endif
+        if (pacer) {
+            pacer->set_uncapped(
+                assist_tools_enabled() &&
+                (ev.fast_forward || fast_forward_latched));
+        }
         // System hotkeys (config.ini [KeyMap], rebindable in the launcher).
         if (ev.toggle_fullscreen) {
             // Toggle between windowed and the configured mode. A session
@@ -2681,6 +2839,10 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
             runtime_ui_context.pending_load_slot = 0;
         }
 #endif
+        if (opts.expose_assist_tools && !assist_tools_enabled()) {
+            ev.save_slot = 0;
+            ev.load_slot = 0;
+        }
         if (ev.save_slot) {
             std::string path = slot_path(ev.save_slot);
             std::string e;
@@ -2709,12 +2871,52 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
                 // The load jumped guest time; realign the pacer so it
                 // doesn't burn the accumulated lag catching up.
                 if (pacer) pacer->reset();
+                rewind_history.clear();
+                next_rewind_capture_frame = ppu.frame_count();
             } else {
                 std::fprintf(stderr,
                              "[gbarecomp:runtime] savestate load (slot %d) "
                              "failed: %s\n", ev.load_slot, e.c_str());
             }
         }
+#if defined(GBARECOMP_RUNTIME_UI)
+        if (runtime_ui_context.pending_rewind) {
+            runtime_ui_context.pending_rewind = false;
+            const uint64_t current = ppu.frame_count();
+            const uint64_t target = current > 60 ? current - 60 : 0;
+            std::size_t target_index = rewind_history.size();
+            for (std::size_t i = rewind_history.size(); i > 0; --i) {
+                if (rewind_history[i - 1].frame <= target) {
+                    target_index = i - 1;
+                    break;
+                }
+            }
+            if (target_index == rewind_history.size()) {
+                std::fprintf(stderr,
+                             "[gbarecomp:runtime] rewind history is not "
+                             "ready yet\n");
+            } else {
+                std::string e;
+                if (do_savestate_load_bytes(
+                        rewind_history[target_index].state, e)) {
+                    while (rewind_history.size() > target_index + 1)
+                        rewind_history.pop_back();
+                    last_presented_frame = ppu.frame_count() - 1;
+                    next_rewind_capture_frame =
+                        ppu.frame_count() + rewind_interval;
+                    if (pacer) pacer->reset();
+                    std::printf("rewind_loaded frame=%llu\n",
+                                static_cast<unsigned long long>(
+                                    ppu.frame_count()));
+                    std::fflush(stdout);
+                } else {
+                    std::fprintf(stderr,
+                                 "[gbarecomp:runtime] rewind failed: %s\n",
+                                 e.c_str());
+                }
+            }
+        }
+#endif
     };
 
     if (args.window) {

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -2769,10 +2769,124 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
                 input_replay_events[input_replay_index].keyinput);
     };
 
+    // Optional monotonic-pump Assist action script for automated validation.
+    // It exercises the same runtime save/load, fast-forward, and rewind paths
+    // as HostWindow input without depending on desktop focus or synthetic OS
+    // modifier state. Format:
+    //   GBARECOMP_ASSIST_SCRIPT="1:fast_on;600:fast_off;620:save1;"
+    //                           "700:load1;800:rewind"
+    // Pump indices never move backward when a state is loaded, so a script
+    // cannot accidentally replay earlier actions after a restore.
+    enum class AssistScriptAction {
+        FastOn,
+        FastOff,
+        Save,
+        Load,
+        Rewind,
+    };
+    struct AssistScriptEvent {
+        uint64_t pump = 0;
+        AssistScriptAction action = AssistScriptAction::FastOff;
+        int slot = 0;
+        std::string label;
+    };
+    std::vector<AssistScriptEvent> assist_script_events;
+    std::size_t assist_script_index = 0;
+    uint64_t assist_script_pump = 0;
+    bool assist_script_fast = false;
+    if (const char* env = std::getenv("GBARECOMP_ASSIST_SCRIPT");
+        env && env[0]) {
+        const std::string script(env);
+        std::size_t start = 0;
+        uint64_t previous_pump = 0;
+        while (start < script.size()) {
+            const std::size_t end = script.find(';', start);
+            const std::string token = script.substr(
+                start, end == std::string::npos ? std::string::npos
+                                                : end - start);
+            const std::size_t colon = token.find(':');
+            char* pump_end = nullptr;
+            const unsigned long long pump = colon == std::string::npos
+                ? 0 : std::strtoull(token.c_str(), &pump_end, 10);
+            const bool pump_valid =
+                colon != std::string::npos && pump > 0 &&
+                pump_end == token.c_str() + colon && pump >= previous_pump;
+            const std::string action = colon == std::string::npos
+                ? std::string{} : token.substr(colon + 1);
+            AssistScriptEvent event;
+            event.pump = static_cast<uint64_t>(pump);
+            event.label = action;
+            bool action_valid = true;
+            if (action == "fast_on") {
+                event.action = AssistScriptAction::FastOn;
+            } else if (action == "fast_off") {
+                event.action = AssistScriptAction::FastOff;
+            } else if (action == "rewind") {
+                event.action = AssistScriptAction::Rewind;
+            } else if (action.rfind("save", 0) == 0 ||
+                       action.rfind("load", 0) == 0) {
+                const bool save = action.rfind("save", 0) == 0;
+                const char* slot_text = action.c_str() + 4;
+                char* slot_end = nullptr;
+                const long slot = std::strtol(slot_text, &slot_end, 10);
+                action_valid = slot_end != slot_text && *slot_end == '\0' &&
+                               slot >= 1 && slot <= 10;
+                event.action = save ? AssistScriptAction::Save
+                                    : AssistScriptAction::Load;
+                event.slot = static_cast<int>(slot);
+            } else {
+                action_valid = false;
+            }
+            if (!pump_valid || !action_valid) {
+                std::fprintf(stderr,
+                             "[gbarecomp:runtime] invalid Assist script "
+                             "event: %s\n", token.c_str());
+                runtime_shutdown();
+                return 1;
+            }
+            assist_script_events.push_back(std::move(event));
+            previous_pump = static_cast<uint64_t>(pump);
+            if (end == std::string::npos) break;
+            start = end + 1;
+        }
+        if (!args.quiet)
+            std::printf("assist_script=ENABLED events=%zu\n",
+                        assist_script_events.size());
+    }
+
     auto pump_host_input = [&]() {
         if (!args.window) return;
         capture_rewind_point();
         auto ev = win.pump();
+        ++assist_script_pump;
+        while (assist_script_index < assist_script_events.size() &&
+               assist_script_events[assist_script_index].pump <=
+                   assist_script_pump) {
+            const AssistScriptEvent& event =
+                assist_script_events[assist_script_index++];
+            switch (event.action) {
+                case AssistScriptAction::FastOn:
+                    assist_script_fast = true;
+                    break;
+                case AssistScriptAction::FastOff:
+                    assist_script_fast = false;
+                    break;
+                case AssistScriptAction::Save:
+                    ev.save_slot = event.slot;
+                    break;
+                case AssistScriptAction::Load:
+                    ev.load_slot = event.slot;
+                    break;
+                case AssistScriptAction::Rewind:
+                    ev.rewind = true;
+                    break;
+            }
+            std::printf("assist_script_event pump=%llu action=%s\n",
+                        static_cast<unsigned long long>(event.pump),
+                        event.label.c_str());
+            std::fflush(stdout);
+        }
+        ev.fast_forward = ev.fast_forward || assist_script_fast;
         if (!input_replay_requested) bus.io().set_keyinput(ev.keyinput);
         if (bus.gyro().active()) {
             // Mouse-drag is angular velocity, not absolute angle: moving while

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -85,6 +85,7 @@ extern "C" unsigned long long g_runtime_irq_entries;
 // instead of unwinding the guest stack — see the windowed runner below.
 void runtime_set_frame_present_hook(std::function<bool()>);
 void runtime_set_host_service_hook(std::function<void()>);
+void runtime_set_frame_start_hook(std::function<void()>);
 
 #ifndef GBARECOMP_DEFAULT_GAME_CONFIG
 #define GBARECOMP_DEFAULT_GAME_CONFIG "game.toml"
@@ -757,7 +758,8 @@ void find_config_arg(int argc, char** argv, Args* args) {
             continue;
         }
         if ((s == "--bios" || s == "--rom" || s == "--bios-sha1" ||
-             s == "--rom-sha1" || s == "--steps" || s == "--frames" ||
+             s == "--rom-sha1" || s == "--rom-crc32" ||
+             s == "--steps" || s == "--frames" ||
              s == "--scale" || s == "--tcp" || s == "--dump-bmp" ||
              s == "--dump-png" || s == "--load-state" ||
              s == "--view-width" || s == "--widescreen" ||
@@ -851,6 +853,12 @@ bool parse_cli(int argc, char** argv, Args* args, std::string* err) {
             const char* v = need_value("--rom-sha1");
             if (!v) return false;
             args->rom_sha1 = lower_ascii(v);
+            continue;
+        }
+        if (s == "--rom-crc32") {
+            const char* v = need_value("--rom-crc32");
+            if (!v) return false;
+            args->rom_crc32 = parse_hex_u32(v);
             continue;
         }
         if (s == "--steps") {
@@ -2328,6 +2336,17 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
         }
     };
     FramePhaseRing frame_phase;
+    auto publish_extended_view_frame = [&]() {
+        if (!opts.extended_view_frame) return;
+        ExtendedViewFrameInfo info{};
+        info.frame_count = ppu.frame_count();
+        info.view_width = ppu.render_width();
+        info.extra_left = ppu.view_extra_left();
+        info.extra_right = ppu.view_extra_right();
+        info.io = bus.io().raw();
+        info.io_size = gba::GbaIo::kIoSize;
+        opts.extended_view_frame(&info);
+    };
     auto apply_runtime_view_width = [&](std::uint32_t target) -> bool {
         const ViewGeometry geometry = resolve_view_geometry(
             static_cast<int>(target),
@@ -2348,6 +2367,10 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
             opts.extended_view_init(ppu.view_extra_left(), ppu.view_extra_right());
             extended_view_initialized = true;
         }
+        // A live resize can change the policy from native to authored margins
+        // midway through the host loop. Publish immediately so the fresh frame
+        // rendered below uses the new game's policy rather than the prior size.
+        publish_extended_view_frame();
         live_fb.assign(ppu.render_bytes(), 0);
         return true;
     };
@@ -3069,6 +3092,10 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
     if (args.window) {
         runtime_set_host_service_hook([&]() { win.service_events(); });
     }
+    if (opts.extended_view_frame) {
+        runtime_set_frame_start_hook(publish_extended_view_frame);
+        publish_extended_view_frame();
+    }
 
     // Present-in-place (structural fix for frame-boundary resume dispatch-misses).
     // When windowed, register a hook so the per-VBlank frame-present yield presents
@@ -3551,6 +3578,7 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
     // pacer, live_fb, …) go out of scope at function return.
     runtime_set_frame_present_hook(nullptr);
     runtime_set_host_service_hook(nullptr);
+    runtime_set_frame_start_hook(nullptr);
     frame_phase.dump();  // HP-002: flush the phase ring (env-gated CSV)
     // HP-002: flush the always-on MMIO write ring (gba_io.cpp) to CSV.
     // GBARECOMP_MMIO_DUMP=<path>. Offline analysis derives the scanline of

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -2414,7 +2414,8 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
                 std::filesystem::path p(argv[0]);
                 if (p.has_parent_path()) exe_dir = p.parent_path().string();
             }
-            win.load_input_config(exe_dir.c_str());
+            win.load_input_config(exe_dir.c_str(),
+                                  opts.assist_tools_enabled_by_default);
         }
         if (args.fullscreen) win.set_fullscreen(args.fullscreen);
         win.set_volume(args.volume);
@@ -2424,7 +2425,7 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
         runtime_ui_context.gyro_sensitivity = &args.gyro_sensitivity;
         runtime_ui_context.assist_tools_exposed = opts.expose_assist_tools;
         runtime_ui_context.assist_tools_enabled =
-            opts.assist_tools_enabled_by_default;
+            win.assist_tools_enabled();
         runtime_ui_context.state_slot_count = std::clamp<int>(
             opts.save_state_slot_count ? opts.save_state_slot_count : 9,
             1, 10);
@@ -2619,7 +2620,7 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
         return !opts.expose_assist_tools ||
                runtime_ui_context.assist_tools_enabled;
 #else
-        return true;
+        return !opts.expose_assist_tools || win.assist_tools_enabled();
 #endif
     };
     auto capture_rewind_point = [&]() {
@@ -2879,9 +2880,13 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
                              "failed: %s\n", ev.load_slot, e.c_str());
             }
         }
+        bool rewind_requested = ev.rewind;
 #if defined(GBARECOMP_RUNTIME_UI)
-        if (runtime_ui_context.pending_rewind) {
-            runtime_ui_context.pending_rewind = false;
+        rewind_requested = rewind_requested ||
+                           runtime_ui_context.pending_rewind;
+        runtime_ui_context.pending_rewind = false;
+#endif
+        if (rewind_requested && assist_tools_enabled()) {
             const uint64_t current = ppu.frame_count();
             const uint64_t target = current > 60 ? current - 60 : 0;
             std::size_t target_index = rewind_history.size();
@@ -2916,7 +2921,6 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
                 }
             }
         }
-#endif
     };
 
     if (args.window) {

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -207,6 +207,7 @@ struct Args {
 #define GBARECOMP_UI_KEY_FPS        "display.fps_readout"
 #define GBARECOMP_UI_KEY_ASSIST_ENABLED "assist.enabled"
 #define GBARECOMP_UI_KEY_FAST_FORWARD   "assist.fast_forward"
+#define GBARECOMP_UI_KEY_FAST_FORWARD_SPEED "assist.fast_forward_speed"
 #define GBARECOMP_UI_KEY_REWIND          "assist.rewind"
 
 struct RuntimeUiContext {
@@ -225,6 +226,7 @@ struct RuntimeUiContext {
     bool assist_tools_exposed = false;
     bool assist_tools_enabled = true;
     bool fast_forward_latched = false;
+    int fast_forward_multiplier = 4;
     // Game-supplied handlers for keys the engine does not own.
     const RunOptions* opts = nullptr;
 };
@@ -244,6 +246,9 @@ int runtime_ui_get(void* opaque, const RecompRuntimeUiItem* item, int* out) {
         *out = c->assist_tools_enabled;
     else if (std::strcmp(item->key, GBARECOMP_UI_KEY_FAST_FORWARD) == 0)
         *out = c->fast_forward_latched;
+    else if (std::strcmp(item->key,
+                         GBARECOMP_UI_KEY_FAST_FORWARD_SPEED) == 0)
+        *out = c->fast_forward_multiplier;
 #if defined(RECOMP_RUNTIME_UI_KEY_GYRO_SENSITIVITY)
     else if (std::strcmp(item->key, RECOMP_RUNTIME_UI_KEY_GYRO_SENSITIVITY) == 0 &&
              c->gyro_sensitivity)
@@ -278,6 +283,9 @@ int runtime_ui_set(void* opaque, const RecompRuntimeUiItem* item, int value) {
         if (!c->assist_tools_enabled) c->fast_forward_latched = false;
     } else if (std::strcmp(item->key, GBARECOMP_UI_KEY_FAST_FORWARD) == 0)
         c->fast_forward_latched = value != 0;
+    else if (std::strcmp(item->key,
+                         GBARECOMP_UI_KEY_FAST_FORWARD_SPEED) == 0)
+        c->fast_forward_multiplier = std::clamp(value, 2, 10);
 #if defined(RECOMP_RUNTIME_UI_KEY_GYRO_SENSITIVITY)
     else if (std::strcmp(item->key, RECOMP_RUNTIME_UI_KEY_GYRO_SENSITIVITY) == 0 &&
              c->gyro_sensitivity)
@@ -2415,7 +2423,8 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
                 if (p.has_parent_path()) exe_dir = p.parent_path().string();
             }
             win.load_input_config(exe_dir.c_str(),
-                                  opts.assist_tools_enabled_by_default);
+                                  opts.assist_tools_enabled_by_default,
+                                  opts.assist_fast_forward_multiplier_default);
         }
         if (args.fullscreen) win.set_fullscreen(args.fullscreen);
         win.set_volume(args.volume);
@@ -2426,6 +2435,8 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
         runtime_ui_context.assist_tools_exposed = opts.expose_assist_tools;
         runtime_ui_context.assist_tools_enabled =
             win.assist_tools_enabled();
+        runtime_ui_context.fast_forward_multiplier =
+            win.fast_forward_multiplier();
         runtime_ui_context.state_slot_count = std::clamp<int>(
             opts.save_state_slot_count ? opts.save_state_slot_count : 9,
             1, 10);
@@ -2551,6 +2562,19 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
             fast_forward_item.type        = RECOMP_RUNTIME_UI_BOOL;
             runtime_ui_extras.push_back(fast_forward_item);
 
+            RecompRuntimeUiItem fast_forward_speed_item{};
+            fast_forward_speed_item.key =
+                GBARECOMP_UI_KEY_FAST_FORWARD_SPEED;
+            fast_forward_speed_item.section = "Assist Tools";
+            fast_forward_speed_item.label = "Fast-forward speed";
+            fast_forward_speed_item.description =
+                "Target emulation multiplier while Fast-forward is active.";
+            fast_forward_speed_item.type = RECOMP_RUNTIME_UI_INT;
+            fast_forward_speed_item.minimum = 2;
+            fast_forward_speed_item.maximum = 10;
+            fast_forward_speed_item.step = 1;
+            runtime_ui_extras.push_back(fast_forward_speed_item);
+
             if (opts.rewind_history_seconds > 0) {
                 RecompRuntimeUiItem rewind_item{};
                 rewind_item.key         = GBARECOMP_UI_KEY_REWIND;
@@ -2623,6 +2647,9 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
         return !opts.expose_assist_tools || win.assist_tools_enabled();
 #endif
     };
+    bool fast_forward_active = false;
+    int fast_forward_multiplier = std::clamp(
+        win.fast_forward_multiplier(), 2, 10);
     auto capture_rewind_point = [&]() {
         if (!rewind_capacity || !assist_tools_enabled()) return;
         const uint64_t frame = ppu.frame_count();
@@ -2802,12 +2829,14 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
         bool fast_forward_latched = false;
 #if defined(GBARECOMP_RUNTIME_UI)
         fast_forward_latched = runtime_ui_context.fast_forward_latched;
+        fast_forward_multiplier = std::clamp(
+            runtime_ui_context.fast_forward_multiplier, 2, 10);
+#else
+        fast_forward_multiplier = std::clamp(
+            win.fast_forward_multiplier(), 2, 10);
 #endif
-        if (pacer) {
-            pacer->set_uncapped(
-                assist_tools_enabled() &&
-                (ev.fast_forward || fast_forward_latched));
-        }
+        fast_forward_active = assist_tools_enabled() &&
+                              (ev.fast_forward || fast_forward_latched);
         // System hotkeys (config.ini [KeyMap], rebindable in the launcher).
         if (ev.toggle_fullscreen) {
             // Toggle between windowed and the configured mode. A session
@@ -2950,21 +2979,26 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
             uint64_t frame = ppu.frame_count();
             if (frame != last_presented_frame) {
                 const uint64_t fp_t0 = FramePhaseRing::now_ns();
-                const bool view_changed = sync_resize_driven_view();
-                if (ppu.has_latched_framebuffer() && !view_changed) {
-                    std::memcpy(live_fb.data(), ppu.latched_framebuffer(),
-                                ppu.render_bytes());
-                } else {
-                    ppu.render(live_fb.data(), bus.io().read16(0x000),
-                               bus.io().raw(), bus.vram_ptr(), bus.oam_ptr(),
-                               bus.pal_ptr());
+                const bool present_frame = !fast_forward_active ||
+                    (frame % static_cast<uint64_t>(
+                         fast_forward_multiplier) == 0);
+                if (present_frame) {
+                    const bool view_changed = sync_resize_driven_view();
+                    if (ppu.has_latched_framebuffer() && !view_changed) {
+                        std::memcpy(live_fb.data(), ppu.latched_framebuffer(),
+                                    ppu.render_bytes());
+                    } else {
+                        ppu.render(live_fb.data(), bus.io().read16(0x000),
+                                   bus.io().raw(), bus.vram_ptr(), bus.oam_ptr(),
+                                   bus.pal_ptr());
+                    }
                 }
                 const uint64_t fp_t1 = FramePhaseRing::now_ns();
-                win.present(live_fb.data());
+                if (present_frame) win.present(live_fb.data());
                 const uint64_t fp_t2 = FramePhaseRing::now_ns();
                 int16_t audio_buf[2048];
                 std::size_t n = bus.audio().drain_samples(audio_buf, 2048);
-                if (n > 0) {
+                if (n > 0 && !fast_forward_active) {
                     gba_mod_audio_mix(audio_buf, n);
                     win.push_audio_samples(audio_buf, n);
                 }
@@ -2977,10 +3011,12 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
                 if (input_replay_requested) apply_input_replay();
                 const uint64_t fp_t4 = FramePhaseRing::now_ns();
                 last_presented_frame = frame;
-                ++frames_presented;
-                if (args.frames >= 0 && frames_presented >= args.frames)
-                    host_quit = true;
-                if (pacer) pacer->wait_for_next_frame();
+                if (present_frame) {
+                    ++frames_presented;
+                    if (args.frames >= 0 && frames_presented >= args.frames)
+                        host_quit = true;
+                    if (pacer) pacer->wait_for_next_frame();
+                }
                 frame_phase.record(frame, fp_t0, fp_t1, fp_t2, fp_t3, fp_t4,
                                    FramePhaseRing::now_ns());
             }
@@ -3314,17 +3350,22 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
             uint64_t frame = ppu.frame_count();
             if (frame != last_presented_frame) {
                 const uint64_t fp_t0 = FramePhaseRing::now_ns();
-                const bool view_changed = sync_resize_driven_view();
-                if (ppu.has_latched_framebuffer() && !view_changed) {
-                    std::memcpy(live_fb.data(), ppu.latched_framebuffer(),
-                                ppu.render_bytes());
-                } else {
-                    ppu.render(live_fb.data(), bus.io().read16(0x000),
-                               bus.io().raw(), bus.vram_ptr(), bus.oam_ptr(),
-                               bus.pal_ptr());
+                const bool present_frame = !fast_forward_active ||
+                    (frame % static_cast<uint64_t>(
+                         fast_forward_multiplier) == 0);
+                if (present_frame) {
+                    const bool view_changed = sync_resize_driven_view();
+                    if (ppu.has_latched_framebuffer() && !view_changed) {
+                        std::memcpy(live_fb.data(), ppu.latched_framebuffer(),
+                                    ppu.render_bytes());
+                    } else {
+                        ppu.render(live_fb.data(), bus.io().read16(0x000),
+                                   bus.io().raw(), bus.vram_ptr(), bus.oam_ptr(),
+                                   bus.pal_ptr());
+                    }
                 }
                 const uint64_t fp_t1 = FramePhaseRing::now_ns();
-                win.present(live_fb.data());
+                if (present_frame) win.present(live_fb.data());
                 // Framedump (capture runs only) is attributed to present_us.
                 if (framedump_dir && frame >= framedump_start &&
                     framedump_written < framedump_max) {
@@ -3338,7 +3379,7 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
                 const uint64_t fp_t2 = FramePhaseRing::now_ns();
                 int16_t audio_buf[2048];
                 std::size_t n = bus.audio().drain_samples(audio_buf, 2048);
-                if (n > 0) {
+                if (n > 0 && !fast_forward_active) {
                     gba_mod_audio_mix(audio_buf, n);
                     win.push_audio_samples(audio_buf, n);
                 }
@@ -3347,13 +3388,16 @@ int run_game(int argc, char** argv, const RunOptions& opts) {
                 const uint64_t fp_t4 = FramePhaseRing::now_ns();
                 dispatches_since_pump = 0;
                 last_presented_frame = frame;
-                ++frames_presented;
-                if (args.frames >= 0 && frames_presented >= args.frames) {
-                    host_quit = true;
+                if (present_frame) {
+                    ++frames_presented;
+                    if (args.frames >= 0 && frames_presented >= args.frames) {
+                        host_quit = true;
+                    }
+                    // Normal play presents/paces every frame. Fast-forward
+                    // runs N guest frames per one paced host presentation,
+                    // making its selected multiplier independent of monitor Hz.
+                    if (pacer) pacer->wait_for_next_frame();
                 }
-                // Pace to real GBA time. Decoupled from monitor vsync
-                // (MC-HP-004); hold Tab to uncap (fast-forward).
-                if (pacer) pacer->wait_for_next_frame();
                 frame_phase.record(frame, fp_t0, fp_t1, fp_t2, fp_t3, fp_t4,
                                    FramePhaseRing::now_ns());
             }

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -48,6 +48,25 @@ struct RunOptions {
     std::uint16_t max_resize_view_width = 240;
     bool resize_driven_view = false;
 
+    // Host-window presentation policy, independent of extended guest view.
+    // When true the player may freely reshape a window while SDL keeps the
+    // native game image aspect-correct with letter/pillar boxing.
+    bool freely_resizable_window = false;
+
+    // Player-facing diagnostics. The counter reports actual presents per
+    // second in the native window title; games may ship it enabled while
+    // retaining the shared hotkey/menu toggle.
+    bool show_fps_by_default = false;
+
+    // Optional shared Assist Tools surface. Games opt into the menu and choose
+    // its resource bounds; the implementation remains engine-owned and
+    // reusable. Slot hotkeys continue to cover 1-9, while menus can reach 10.
+    bool expose_assist_tools = false;
+    bool assist_tools_enabled_by_default = true;
+    std::uint8_t save_state_slot_count = 9;
+    std::uint8_t rewind_history_seconds = 0;
+    std::uint8_t rewind_capture_interval_frames = 15;
+
     // Optional game-owned content initializer. Called exactly once, after the
     // first non-native view has been authorized and applied. For a fixed view
     // that is during startup; for resize-driven view it is deferred until the

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -12,6 +12,19 @@
 
 namespace gbarecomp {
 
+// Read-only state published to an opted-in game's extended-view policy once
+// per emulated frame. The shared runtime owns the wider surface; the game owns
+// the decision about whether the current scene has authentic margin content.
+// Keeping this view deliberately small avoids exposing mutable bus internals.
+struct ExtendedViewFrameInfo {
+    std::uint64_t frame_count = 0;
+    std::uint32_t view_width = 240;
+    std::uint32_t extra_left = 0;
+    std::uint32_t extra_right = 0;
+    const std::uint8_t* io = nullptr;
+    std::size_t io_size = 0;
+};
+
 // Per-game built-in defaults baked into a game runner at compile time.
 // Lets a standalone release .exe (e.g. MinishCapRecomp.exe) ship
 // without a sibling game.toml — the runtime falls back to these
@@ -75,6 +88,13 @@ struct RunOptions {
     // the generated function-entry fast path too.
     void (*extended_view_init)(std::uint32_t extra_left,
                                std::uint32_t extra_right) = nullptr;
+
+    // Optional game-owned per-frame margin policy. It runs at the start of an
+    // emulated frame, before scanline 0 is composed, and again immediately
+    // after a live adaptive resize. Games may use the read-only PPU registers
+    // above to select shared margin providers/pillarboxing. Null leaves the
+    // established renderer behavior unchanged.
+    void (*extended_view_frame)(const ExtendedViewFrameInfo* frame) = nullptr;
 
     // This cartridge carries a solar sensor. Unlike the RTC there is no ROM
     // signature to detect one from, so it has to be declared. Games that leave
@@ -158,6 +178,17 @@ struct RunOptions {
     const char* launcher_save_path = nullptr;   // explicit save file (game.toml
                                                 // [save].path); null => <rom>.sav
                                                 // derived from the seeded ROM
+    // Opt into recomp-ui's verified IPS/IPS32/BPS source-ROM patch surface.
+    // Patched images are generated under the executable's mods/rom-patches
+    // cache; the original ROM and patch file are never modified.
+    bool launcher_enable_rom_patches = false;
+    const char* launcher_rom_patch_note = nullptr;
+    // Translation-specific builds can verify a stock source independently
+    // from builtin_rom_sha1 (the target image the generated corpus expects).
+    const char* launcher_source_rom_sha1 = nullptr;
+    // Lowercase SHA-1 of the only accepted patched output for a corpus built
+    // against one translation release. Null leaves data-only patches open.
+    const char* launcher_required_patch_sha1 = nullptr;
     // Keep an implemented extended-view mode out of the public launcher while
     // it is still being profiled. Explicit CLI/TOML opt-ins remain available.
     // Defaults true so existing games (including MMZ) retain today's UI.

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -63,6 +63,7 @@ struct RunOptions {
     // reusable. Slot hotkeys continue to cover 1-9, while menus can reach 10.
     bool expose_assist_tools = false;
     bool assist_tools_enabled_by_default = true;
+    std::uint8_t assist_fast_forward_multiplier_default = 4;
     std::uint8_t save_state_slot_count = 9;
     std::uint8_t rewind_history_seconds = 0;
     std::uint8_t rewind_capture_interval_frames = 15;

--- a/src/runtime/runtime_bus_bridge.cpp
+++ b/src/runtime/runtime_bus_bridge.cpp
@@ -63,6 +63,10 @@ extern "C" unsigned long long g_prof_scanline_count = 0;
 // guest input. It keeps a window responsive while one emulated frame spends a
 // long time in translated software-rendering or decode code.
 std::function<void()> g_host_service_hook;
+// Optional game-owned extended-view policy. It runs on the emulation thread at
+// the exact frame boundary, before scanline 0 of the next frame is composed.
+// Null preserves the established renderer path for every existing game.
+std::function<void()> g_frame_start_hook;
 static const bool g_phase_prof = [] {
     const char* e = std::getenv("GBARECOMP_PHASE_PROF");
     bool on = (e != nullptr) && !(e[0] == '0' && e[1] == '\0');
@@ -554,6 +558,9 @@ static void tick_devices(gba::GbaBus* bus, gba::GbaPpu* ppu, uint32_t cycles) {
             ++g_runtime_vblank_starts;
             bus->io().run_timed_dma(1);   // VBlank-timed DMA
         }
+        if (events.frame_completed && g_frame_start_hook) {
+            g_frame_start_hook();
+        }
         if (events.vblank_started && (ds & 0x0008u)) {
             bus->io().request_irq(gba::GbaIo::IrqVBlank);
         }
@@ -920,6 +927,10 @@ void runtime_set_frame_present_hook(std::function<bool()> h) {
 
 void runtime_set_host_service_hook(std::function<void()> h) {
     g_host_service_hook = std::move(h);
+}
+
+void runtime_set_frame_start_hook(std::function<void()> h) {
+    g_frame_start_hook = std::move(h);
 }
 
 extern "C" bool runtime_should_yield(void) {

--- a/src/runtime/runtime_bus_bridge.cpp
+++ b/src/runtime/runtime_bus_bridge.cpp
@@ -892,6 +892,27 @@ std::function<bool()> g_frame_present_hook;
 // runner — one return only frees one frame. Cleared when a hook is (re)set.
 bool g_frame_present_quit = false;
 
+// Present-in-place deliberately preserves the generated host call chain across
+// frames, but some guest script engines keep a call active for thousands of
+// frames. Periodically unwind at a completed VBlank before the fixed generated
+// call-return stack reaches its hard limit. The runner immediately redispatches
+// the already-published PC, so guest execution is unchanged.
+constexpr uint32_t kPresentInPlaceCallDepthLimit = 512u;
+
+uint32_t present_in_place_call_depth_limit() {
+    static const uint32_t limit = [] {
+        const char* value = std::getenv(
+            "GBARECOMP_PRESENT_IN_PLACE_CALL_DEPTH");
+        if (!value || value[0] == '\0')
+            return kPresentInPlaceCallDepthLimit;
+        const unsigned long parsed = std::strtoul(value, nullptr, 0);
+        return parsed > 0u && parsed < 1024u
+            ? static_cast<uint32_t>(parsed)
+            : kPresentInPlaceCallDepthLimit;
+    }();
+    return limit;
+}
+
 void runtime_set_frame_present_hook(std::function<bool()> h) {
     g_frame_present_hook = std::move(h);
     g_frame_present_quit = false;
@@ -961,8 +982,28 @@ extern "C" bool runtime_should_yield(void) {
             // quit. With no hook (headless/TCP), keep the original unwind path.
             if (g_frame_present_hook) {
                 bool quit = g_frame_present_hook();
-                if (quit) g_frame_present_quit = true;  // sticky: full unwind
-                return quit;
+                if (quit) {
+                    g_frame_present_quit = true;  // sticky: full unwind
+                    return true;
+                }
+                const uint32_t call_depth = runtime_call_stack_depth();
+                const uint32_t call_depth_limit =
+                    present_in_place_call_depth_limit();
+                if (call_depth >= call_depth_limit) {
+                    static unsigned long long forced_unwinds = 0;
+                    ++forced_unwinds;
+                    // Keep the diagnostic useful without flooding stderr in a
+                    // guest that repeatedly builds long-lived script chains.
+                    if ((forced_unwinds & (forced_unwinds - 1u)) == 0u) {
+                        std::fprintf(stderr,
+                            "runtime: present-in-place call-depth unwind "
+                            "depth=%u limit=%u count=%llu pc=0x%08X\n",
+                            call_depth, call_depth_limit, forced_unwinds,
+                            g_cpu.R[15]);
+                    }
+                    return true;
+                }
+                return false;
             }
             return true;
         }

--- a/tests/ppu_smoke/test_main.cpp
+++ b/tests/ppu_smoke/test_main.cpp
@@ -569,6 +569,51 @@ void test_extended_view_obj_attr_x_is_explicitly_opt_in() {
     gba::g_ws_obj_attr_x_provider = nullptr;
 }
 
+void test_extended_view_obj_native_clip_is_opt_in() {
+    Fixture f;
+    disable_all_objects(f);
+    // OBJ 0: parked just off the native left edge (signed 9-bit X = -4), the
+    // idiom games use to hide sprites. Vanilla wide draws its colored texels
+    // in the left margin; the opt-in clip must not.
+    store16(&f.oam[0], 0x0000);
+    store16(&f.oam[2], 0x01FC);
+    store16(&f.oam[4], 0x0000);
+    // OBJ 1: fully inside the native viewport at X=8; must be unaffected.
+    store16(&f.oam[8], 0x0000);
+    store16(&f.oam[10], 8);
+    store16(&f.oam[12], 0x0000);
+    f.vram[0x10000] = 0x11;          // Tile 0: first two texels use color 1.
+    store16(&f.pal[0x202], 0x001F);  // OBJ color 1 = red.
+
+    f.ppu.set_view_margins(24, 24, 0, 0);
+    std::vector<uint8_t> wide(gba::GbaPpu::kMaxFramebufferBytes, 0);
+    f.ppu.render(wide.data(), 0x1000, f.io.data(), f.vram.data(),
+                 f.oam.data(), f.pal.data());
+    expect_pixel(wide.data() + (24u - 4u) * 3u, 255, 0, 0,
+                 "vanilla wide margin OBJ");
+    expect_pixel(wide.data() + (24u + 8u) * 3u, 255, 0, 0,
+                 "vanilla wide center OBJ");
+
+    gba::g_ws_obj_native_clip = 1;
+    std::fill(wide.begin(), wide.end(), 0);
+    f.ppu.render(wide.data(), 0x1000, f.io.data(), f.vram.data(),
+                 f.oam.data(), f.pal.data());
+    expect_pixel(wide.data() + (24u - 4u) * 3u, 0, 0, 0,
+                 "clipped margin OBJ leaked into margin");
+    expect_pixel(wide.data() + (24u + 8u) * 3u, 255, 0, 0,
+                 "clip altered native-viewport OBJ");
+    gba::g_ws_obj_native_clip = 0;
+
+    // The faithful native renderer must be inert to the flag.
+    gba::g_ws_obj_native_clip = 1;
+    f.ppu.set_view_margins(0, 0, 0, 0);
+    f.ppu.render(f.rgb.data(), 0x1000, f.io.data(), f.vram.data(),
+                 f.oam.data(), f.pal.data());
+    expect_pixel(f.rgb.data() + 8u * 3u, 255, 0, 0,
+                 "native render changed by OBJ clip flag");
+    gba::g_ws_obj_native_clip = 0;
+}
+
 void test_extended_view_extends_nearest_window_edge() {
     Fixture f;
     store16(&f.io[0x08], 0x0180);  // BG0 256-color, screen block 1.
@@ -1660,6 +1705,7 @@ int main() {
     test_obj_only_palette_backdrop_is_not_policy_black();
     test_extended_view_obj_x_is_explicitly_opt_in();
     test_extended_view_obj_attr_x_is_explicitly_opt_in();
+    test_extended_view_obj_native_clip_is_opt_in();
     test_extended_view_extends_nearest_window_edge();
     test_bitmap_mode3_direct_color_and_affine_origin();
     test_bitmap_mode4_palette_transparency_and_page_flip();


### PR DESCRIPTION
## Summary

- add reusable, opt-in Assist runtime support for save states, rewind, fast-forward, configurable bindings, and a bounded speed multiplier
- add resizable host-window and frame-pacing support, including title-bar FPS reporting and audio behavior suited to accelerated presentation
- add game-agnostic presentation hooks for patched ROM identity and adaptive/widescreen rendering without embedding any game-specific rules
- add parent-project build staging helpers so consumers can package the shared runtime consistently

## Why

These capabilities were first exercised by the Summon Night: Swordcraft Story 3 recomp project. This PR extracts only the reusable runtime and presentation seams so other GBA recomp projects can opt into the same features while keeping title-specific policy in their own repositories.

All new behavior is opt-in; existing consumers retain their current defaults.

## Validation

- configured and compiled `gbarecomp_runtime` and `gbarecomp_debug` from current `main`
- `audio_drc_tests`
- `bus_tests`
- `ppu_smoke_tests`
- `save_config_tests`
- `presentation_layout_tests`

All five focused test targets passed on Windows with MinGW/Ninja.

## Notes for review

- the save-state byte loader preserves the upstream parser's overflow-safe bounds checks
- fast-forward suppresses queued host audio while retaining the upstream mod-audio mixer on normal-speed frames
- presentation pacing remains the default clock; the new controls only alter it when explicitly enabled by a host
- no ROM, BIOS, translation patch, or title-specific data is included
