### PR TITLE
Keep the symbol-import goldens byte-identical on checkout (fixes symbol_import_golden on Windows)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Golden files are compared BYTE-for-byte by the test suite
+# (tests/symbol_import/run_golden.py uses filecmp with shallow=False), and the
+# importer that produces them writes LF explicitly (newline="\n"). A checkout
+# that translates line endings therefore rewrites the goldens to CRLF while the
+# produced files stay LF, and the compare fails — on Windows, where
+# core.autocrlf defaults to true, symbol_import_golden fails for this reason
+# alone. Worse, the failure is near-silent: the test's diff uses splitlines(),
+# which normalises line endings, so it reports the files as differing while
+# printing no differences at all.
+#
+# Pin them so the bytes on disk match the bytes committed, whatever the
+# consumer's git config.
+tests/symbol_import/golden/* -text


### PR DESCRIPTION
`symbol_import_golden` fails on Windows, and only on Windows:

```
7/26 Test  #7: symbol_import_golden .............***Failed    0.71 sec
symbol_import_golden: FAILED — imported_symbols.tsv, function_boundaries.tsv,
                               imported_data_symbols.tsv, TEST_symbols.toml
```

All four outputs are reported as differing, and the test prints **no diff lines at all**. That combination is the tell:

- `run_golden.py` compares with `filecmp.cmp(produced, golden, shallow=False)` — a **byte** compare;
- but it builds its diff from `read_text(...).splitlines()`, which **normalises line endings**.

So a pure line-ending difference fails the compare and then renders as an empty diff, which makes it look like a mystery rather than a newline problem.

## Cause

Not the importer — `import_decomp_symbols.py` already writes every output with `newline="\n"`. It's **checkout**. Windows git defaults to `core.autocrlf=true`, so the committed LF goldens land on disk as CRLF while the importer keeps emitting LF. Byte compare, LF vs CRLF, fail.

For the one-line case: 216 bytes LF → 221 bytes CRLF.

## Fix

Mark the goldens `-text` so their working-tree bytes match their committed bytes regardless of the consumer's `core.autocrlf` / `core.eol`. This fixes it at the source instead of requiring every downstream CI to configure git before checkout.

Scoped narrowly — `git check-attr` reports `text: unset` for `tests/symbol_import/golden/*` and no attributes for anything else, so no other file's checkout behaviour changes.

`ctest -R symbol_import_golden` still passes on an LF host.

Found when a downstream GBA consumer's Windows/MinGW CI job went red after syncing up to current `main`.